### PR TITLE
chore(ci): add automerge label to dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: scope
-    labels: ["type:chore", "area:sidecar", "deps"]
+    labels: ["type:chore", "area:sidecar", "deps", "automerge"]
 
   - package-ecosystem: npm
     directory: /overlay
@@ -18,7 +18,7 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: scope
-    labels: ["type:chore", "area:overlay", "deps"]
+    labels: ["type:chore", "area:overlay", "deps", "automerge"]
 
   - package-ecosystem: github-actions
     directory: /
@@ -28,4 +28,4 @@ updates:
     commit-message:
       prefix: "chore(ci)"
       include: scope
-    labels: ["type:ci", "deps"]
+    labels: ["type:ci", "deps", "automerge"]


### PR DESCRIPTION
Add `automerge` label to all three Dependabot ecosystems so dependabot-authored PRs trigger the existing `auto-merge.yml` workflow without manual intervention.

Closes the gap where dependabot bumps sat unmerged because nothing applied the label the workflow keys on.