### PR TITLE
ci: harden agent automation pipeline

### DIFF
--- a/.github/agents/MANIFEST.md
+++ b/.github/agents/MANIFEST.md
@@ -1,7 +1,7 @@
 # Vendored Agent Roster
 
 Source: `~/.copilot/agents/` on the dev box (homelab-copilot vault).
-Synced: 2026-04-19T03:21:59Z
+Synced: 2026-04-26T04:05:56Z
 
 These are vendored copies of the canonical team roster. The GitHub
 Copilot coding agent reads them from this directory. To update, re-run

--- a/.github/agents/tech-writer.agent.md
+++ b/.github/agents/tech-writer.agent.md
@@ -90,6 +90,7 @@ docs/
 
 ## CHANGELOG Conventions
 
+
 release-please auto-generates from conventional commits. You step in only when:
 
 - A `feat` commit message was terse → expand the bullet for the changelog

--- a/.github/scripts/apply-tech-writer-patches.py
+++ b/.github/scripts/apply-tech-writer-patches.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Apply tech-writer patches with strict path validation.
+
+Reads a verdict JSON file (path passed as argv[1]) shaped like:
+  {"patches":[{"path":"docs/foo.md","operation":"create|update|delete","content":"..."}]}
+
+Refuses any path that:
+  - is absolute
+  - contains `..` segments
+  - resolves outside the repo root (via realpath)
+  - is not in the docs/ tree or one of the allowed root markdown files
+
+Prints a summary line per applied patch. Exits 0 on success.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ALLOWED_ROOT_FILES = {"README.md", "CONTRIBUTING.md", "SECURITY.md", "CHANGELOG.md"}
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: apply-tech-writer-patches.py VERDICT_JSON", file=sys.stderr)
+        return 2
+
+    repo_root = Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd())).resolve()
+    verdict_path = Path(sys.argv[1])
+    data = json.loads(verdict_path.read_text())
+    patches = data.get("patches", []) or []
+
+    applied = 0
+    for entry in patches:
+        raw_path = entry.get("path", "")
+        op = entry.get("operation", "")
+
+        if not raw_path or not isinstance(raw_path, str):
+            print("::warning::patch missing path; skipping")
+            continue
+
+        # Reject absolute paths and any traversal segments before resolution
+        if os.path.isabs(raw_path) or ".." in Path(raw_path).parts:
+            print(f"::warning::refusing patch with absolute or traversal path: {raw_path}")
+            continue
+
+        # Resolve and verify it stays inside repo root
+        candidate = (repo_root / raw_path).resolve()
+        try:
+            candidate.relative_to(repo_root)
+        except ValueError:
+            print(f"::warning::refusing patch outside repo root: {raw_path}")
+            continue
+
+        rel = candidate.relative_to(repo_root)
+        rel_str = rel.as_posix()
+        # Allowlist: docs/** OR specific root markdown files
+        in_docs = bool(rel.parts) and rel.parts[0] == "docs"
+        in_root_allow = len(rel.parts) == 1 and rel_str in ALLOWED_ROOT_FILES
+        if not (in_docs or in_root_allow):
+            print(f"::warning::refusing patch outside allowlist: {rel_str}")
+            continue
+
+        if op == "delete":
+            if candidate.is_file():
+                candidate.unlink()
+                print(f"  delete: {rel_str}")
+                applied += 1
+        elif op in ("create", "update"):
+            content = entry.get("content", "")
+            if not isinstance(content, str):
+                print(f"::warning::patch content for {rel_str} is not a string; skipping")
+                continue
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            candidate.write_text(content)
+            print(f"  {op}: {rel_str}")
+            applied += 1
+        else:
+            print(f"::warning::unknown operation '{op}' for {rel_str}")
+
+    print(f"applied={applied}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/auto-assign-copilot.yml
+++ b/.github/workflows/auto-assign-copilot.yml
@@ -1,0 +1,62 @@
+name: Auto-assign Copilot to ready issues
+
+# When an issue is opened OR labeled `ready-for-coding-agent`, assign the
+# Copilot coding agent + repo owner. Positive-gate model: nothing happens
+# until you explicitly mark an issue ready, so epics, decision trackers, and
+# blocked work stay out of the agent's queue.
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: auto-assign-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    if: >-
+      contains(github.event.issue.labels.*.name, 'ready-for-coding-agent') &&
+      !contains(github.event.issue.labels.*.name, 'no-copilot') &&
+      !contains(github.event.issue.labels.*.name, 'blocked') &&
+      !contains(github.event.issue.labels.*.name, 'needs-decision') &&
+      !contains(github.event.issue.labels.*.name, 'epic')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify AUTOMATION_PAT is configured
+        env:
+          PAT: ${{ secrets.AUTOMATION_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::AUTOMATION_PAT secret missing. GITHUB_TOKEN cannot call replaceActorsForAssignable with the Copilot bot ID (returns FORBIDDEN)."
+            exit 1
+          fi
+
+      - name: Assign Copilot + repo owner
+        env:
+          # Must be a user PAT — GITHUB_TOKEN cannot call
+          # replaceActorsForAssignable with the Copilot bot ID (returns
+          # FORBIDDEN regardless of repo visibility).
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          set -euo pipefail
+          # Stable bot node ID for the Copilot coding agent
+          COPILOT_BOT_ID="BOT_kgDOC9w8XQ"
+          OWNER_ID=$(gh api "users/${{ github.repository_owner }}" --jq .node_id)
+
+          gh api graphql \
+            --raw-field query='mutation($i:ID!,$a:[ID!]!){
+              replaceActorsForAssignable(input:{assignableId:$i,actorIds:$a}){
+                clientMutationId
+              }
+            }' \
+            -f i="$ISSUE_NODE_ID" \
+            -f "a[]=$COPILOT_BOT_ID" \
+            -f "a[]=$OWNER_ID"
+
+          echo "Assigned Copilot + ${{ github.repository_owner }} to issue #${{ github.event.issue.number }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, review_requested]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, review_requested]
   push:
     branches: [main]
 

--- a/.github/workflows/copilot-finalize.yml
+++ b/.github/workflows/copilot-finalize.yml
@@ -19,7 +19,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 concurrency:
   group: copilot-finalize-${{ github.event.pull_request.number }}
@@ -37,6 +36,7 @@ jobs:
       github.event.pull_request.draft == true &&
       github.event.sender.login == 'Copilot'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Verify AUTOMATION_PAT is configured
         env:
@@ -59,10 +59,12 @@ jobs:
           set -euo pipefail
           echo "Finalizing Copilot PR #$PR in $REPO"
 
-          # Idempotent: gh pr ready is a no-op if already ready
-          gh pr ready "$PR" --repo "$REPO" || echo "::warning::pr ready failed (may already be ready)"
+          # gh pr ready is idempotent; do NOT swallow failures — a silent
+          # failure here would leave the automerge label on a still-draft PR
+          # and auto-merge.yml would skip without any error signal.
+          gh pr ready "$PR" --repo "$REPO"
 
-          # Idempotent: --add-label is a no-op if already applied
+          # --add-label is idempotent
           gh pr edit "$PR" --repo "$REPO" --add-label automerge
 
           echo "Final state:"

--- a/.github/workflows/copilot-finalize.yml
+++ b/.github/workflows/copilot-finalize.yml
@@ -1,0 +1,69 @@
+name: copilot-finalize
+
+# When the Copilot coding agent (`copilot-swe-agent[bot]`) finishes its work, it
+# fires `copilot_work_finished` immediately followed by `review_requested` (with
+# `actor.login == "Copilot"`, the orchestrating GitHub App). The PR remains in
+# draft state, blocking required checks (`ci.yml` skips drafts) and `auto-merge`
+# (which gates on `!draft`). This workflow auto-marks Copilot PRs ready and
+# applies the `automerge` label so the rest of the pipeline can proceed without
+# human intervention.
+#
+# SECURITY: Runs on `pull_request_target` with write privileges. Do NOT add an
+# `actions/checkout` step or execute any code from the PR head — only call the
+# GitHub API against PR metadata.
+
+on:
+  pull_request_target:
+    types: [review_requested]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: copilot-finalize-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    # Only act when:
+    #   1. PR was authored by the Copilot coding agent
+    #   2. PR is still draft (Copilot leaves PRs as draft when done)
+    #   3. The review_requested event was triggered by the orchestrating
+    #      `Copilot` app (not a human asking for review on a draft)
+    if: >-
+      github.event.pull_request.user.login == 'copilot-swe-agent[bot]' &&
+      github.event.pull_request.draft == true &&
+      github.event.sender.login == 'Copilot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify AUTOMATION_PAT is configured
+        env:
+          PAT: ${{ secrets.AUTOMATION_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::AUTOMATION_PAT secret missing. GITHUB_TOKEN cannot trigger downstream workflows (ci.yml on ready_for_review, auto-merge.yml on labeled), so a user PAT is required."
+            exit 1
+          fi
+
+      - name: Mark PR ready and apply automerge label
+        env:
+          # User PAT required so the resulting `ready_for_review` and `labeled`
+          # events re-trigger ci.yml + auto-merge.yml. GITHUB_TOKEN-triggered
+          # events are suppressed by GitHub's anti-recursion rules.
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Finalizing Copilot PR #$PR in $REPO"
+
+          # Idempotent: gh pr ready is a no-op if already ready
+          gh pr ready "$PR" --repo "$REPO" || echo "::warning::pr ready failed (may already be ready)"
+
+          # Idempotent: --add-label is a no-op if already applied
+          gh pr edit "$PR" --repo "$REPO" --add-label automerge
+
+          echo "Final state:"
+          gh pr view "$PR" --repo "$REPO" --json isDraft,labels,mergeStateStatus

--- a/.github/workflows/devops-review.yml
+++ b/.github/workflows/devops-review.yml
@@ -103,11 +103,7 @@ jobs:
             --data-binary @/tmp/devops-req.json > /tmp/devops-resp.json
 
           raw="$(jq -r '.choices[0].message.content // ""' /tmp/devops-resp.json)"
-          parsed="$(RAW="$raw" python3 -c 'import os,sys; s=os.environ["RAW"].strip()
-if s.startswith("```"):
-    s="\n".join(l for l in s.splitlines() if not l.strip().startswith("```")).strip()
-i,j=s.find("{"),s.rfind("}")
-print(s[i:j+1] if i!=-1 and j>=i else s)')"
+          parsed="$(RAW="$raw" python3 -c 'import os; s=os.environ["RAW"].strip(); s="\n".join(l for l in s.splitlines() if not l.strip().startswith("```")).strip() if s.startswith("```") else s; i,j=s.find("{"),s.rfind("}"); print(s[i:j+1] if i!=-1 and j>=i else s)')"
 
           if printf '%s' "$parsed" | jq -e . >/dev/null 2>&1; then
             verdict=$(printf '%s' "$parsed" | jq -r '.verdict // "COMMENT"' | tr '[:lower:]' '[:upper:]')

--- a/.github/workflows/devops-review.yml
+++ b/.github/workflows/devops-review.yml
@@ -1,0 +1,205 @@
+name: devops-review
+
+# LLM-driven devops review of workflow/action changes. Mirrors agent-review.yml
+# but uses devops-engineer.agent.md as the system prompt and only audits when
+# files under .github/workflows/** or .github/actions/** change. PRs that don't
+# touch those paths still post a passing `devops-review` check-run so the gate
+# can be marked required in branch protection without blocking unrelated PRs.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  models: read
+
+concurrency:
+  group: devops-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  devops-review:
+    name: devops-review verdict
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Collect PR context + decide skip
+        id: ctx
+        run: |
+          set -euo pipefail
+          SKIP_REASON=""
+          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            SKIP_REASON="draft"
+          elif [[ "${{ github.event.pull_request.user.login }}" == "dependabot[bot]" ]]; then
+            SKIP_REASON="dependabot"
+          fi
+
+          mapfile -t FILES < <(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+
+          # In-scope only if any changed file lives under workflows/actions
+          IN_SCOPE=false
+          for f in "${FILES[@]}"; do
+            if [[ "$f" == .github/workflows/* || "$f" == .github/actions/* ]]; then
+              IN_SCOPE=true
+              break
+            fi
+          done
+          if [[ "$IN_SCOPE" == "false" && -z "$SKIP_REASON" ]]; then
+            SKIP_REASON="no-workflow-changes"
+          fi
+
+          {
+            echo "skip_reason=${SKIP_REASON}"
+            echo "changed_files<<EOF"
+            printf '%s\n' "${FILES[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run devops-engineer agent (GitHub Models)
+        if: steps.ctx.outputs.skip_reason == ''
+        id: review
+        run: |
+          set -euo pipefail
+
+          diff_content="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -H 'Accept: application/vnd.github.v3.diff')"
+          prompt_content="$(cat .github/agents/devops-engineer.agent.md)"
+          changed_files="${{ steps.ctx.outputs.changed_files }}"
+
+          jq -n \
+            --arg pr "$PR_NUMBER" \
+            --arg base "$BASE_SHA" \
+            --arg head "$HEAD_SHA" \
+            --arg files "$changed_files" \
+            --arg diff "$diff_content" \
+            --arg prompt "$prompt_content" \
+            '{
+              model: "gpt-4.1",
+              temperature: 0.1,
+              messages: [
+                {
+                  role: "system",
+                  content: "You are the tuning-coach devops-engineer reviewer. Apply the conventions in the supplied devops-engineer.agent.md verbatim. Focus areas: GitHub Actions correctness, security (pull_request_target safety, token scopes, secrets exposure, PR-code-execution risks, third-party action SHA pinning), reliability (timeouts, concurrency groups, retry/idempotency), and best practices (least-privilege permissions, no plaintext credentials, no shell-injection from PR-controlled inputs). Use REQUEST_CHANGES only for real blockers (security holes, broken triggers, will-not-run errors). Use COMMENT for non-blocking suggestions. Use APPROVE when the change is safe and correct. Output strict JSON: {\"verdict\":\"APPROVE|REQUEST_CHANGES|COMMENT\",\"summary\":\"string\",\"findings_markdown\":\"string\"}"
+                },
+                {
+                  role: "user",
+                  content: ("Review this PR for devops/CI correctness.\n\nPR: #" + $pr + "\nBase SHA: " + $base + "\nHead SHA: " + $head + "\n\nChanged files:\n" + $files + "\n\nFull diff:\n" + $diff + "\n\nDevops conventions (.github/agents/devops-engineer.agent.md):\n" + $prompt)
+                }
+              ]
+            }' > /tmp/devops-req.json
+
+          curl -fsSL "https://models.inference.ai.azure.com/chat/completions" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data-binary @/tmp/devops-req.json > /tmp/devops-resp.json
+
+          raw="$(jq -r '.choices[0].message.content // ""' /tmp/devops-resp.json)"
+          parsed="$(RAW="$raw" python3 -c 'import os,sys; s=os.environ["RAW"].strip()
+if s.startswith("```"):
+    s="\n".join(l for l in s.splitlines() if not l.strip().startswith("```")).strip()
+i,j=s.find("{"),s.rfind("}")
+print(s[i:j+1] if i!=-1 and j>=i else s)')"
+
+          if printf '%s' "$parsed" | jq -e . >/dev/null 2>&1; then
+            verdict=$(printf '%s' "$parsed" | jq -r '.verdict // "COMMENT"' | tr '[:lower:]' '[:upper:]')
+            summary=$(printf '%s' "$parsed" | jq -r '.summary // "Devops review completed."')
+            findings=$(printf '%s' "$parsed" | jq -r '.findings_markdown // "No issues found."')
+          else
+            verdict="COMMENT"
+            summary="Devops response could not be parsed; posted as comment."
+            findings="$raw"
+          fi
+          case "$verdict" in
+            APPROVE|REQUEST_CHANGES|COMMENT) ;;
+            *) verdict="COMMENT" ;;
+          esac
+
+          {
+            echo "verdict=${verdict}"
+            echo "summary<<EOF"
+            printf '%s\n' "$summary"
+            echo "EOF"
+            echo "findings<<EOF"
+            printf '%s\n' "$findings"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set skip verdict
+        if: steps.ctx.outputs.skip_reason != ''
+        id: skipped
+        run: |
+          set -euo pipefail
+          reason="${{ steps.ctx.outputs.skip_reason }}"
+          {
+            echo "verdict=COMMENT"
+            echo "summary=Devops review skipped (${reason})."
+            echo "findings<<EOF"
+            echo "Devops review skipped for this PR (${reason})."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish PR review (when in-scope)
+        if: steps.ctx.outputs.skip_reason == ''
+        run: |
+          set -euo pipefail
+          verdict="${{ steps.review.outputs.verdict }}"
+          summary="${{ steps.review.outputs.summary }}"
+          findings="${{ steps.review.outputs.findings }}"
+
+          body=$(cat <<EOF
+          🛠️ **devops-review verdict:** ${verdict}
+
+          ${summary}
+
+          ${findings}
+          EOF
+          )
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+            -f event='COMMENT' \
+            -f body="$body" >/dev/null
+
+      - name: Publish devops-review check-run
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.ctx.outputs.skip_reason }}" == "" ]]; then
+            verdict="${{ steps.review.outputs.verdict }}"
+            summary="${{ steps.review.outputs.summary }}"
+            findings="${{ steps.review.outputs.findings }}"
+          else
+            verdict="${{ steps.skipped.outputs.verdict }}"
+            summary="${{ steps.skipped.outputs.summary }}"
+            findings="${{ steps.skipped.outputs.findings }}"
+          fi
+
+          # APPROVE / COMMENT / SKIPPED → success; only REQUEST_CHANGES blocks
+          conclusion='success'
+          if [[ "$verdict" == "REQUEST_CHANGES" ]]; then
+            conclusion='failure'
+          fi
+          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=devops-review" --jq '.check_runs[0].id // empty')"
+          payload=$(jq -n \
+            --arg head_sha "$HEAD_SHA" \
+            --arg completed_at "$completed_at" \
+            --arg conclusion "$conclusion" \
+            --arg title "devops-review: $verdict" \
+            --arg text "$findings" \
+            '{name:"devops-review",head_sha:$head_sha,status:"completed",conclusion:$conclusion,completed_at:$completed_at,output:{title:$title,summary:$title,text:$text}}')
+
+          if [ -n "$existing_id" ]; then
+            update=$(jq 'del(.name,.head_sha)' <<<"$payload")
+            gh api "repos/${GITHUB_REPOSITORY}/check-runs/${existing_id}" -X PATCH --input - <<<"$update" >/dev/null
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST --input - <<<"$payload" >/dev/null
+          fi

--- a/.github/workflows/devops-review.yml
+++ b/.github/workflows/devops-review.yml
@@ -149,41 +149,45 @@ print(s[i:j+1] if i!=-1 and j>=i else s)')"
 
       - name: Publish PR review (when in-scope)
         if: steps.ctx.outputs.skip_reason == ''
+        env:
+          VERDICT: ${{ steps.review.outputs.verdict }}
+          SUMMARY: ${{ steps.review.outputs.summary }}
+          FINDINGS: ${{ steps.review.outputs.findings }}
         run: |
           set -euo pipefail
-          verdict="${{ steps.review.outputs.verdict }}"
-          summary="${{ steps.review.outputs.summary }}"
-          findings="${{ steps.review.outputs.findings }}"
-
-          body=$(cat <<EOF
-          🛠️ **devops-review verdict:** ${verdict}
-
-          ${summary}
-
-          ${findings}
-          EOF
-          )
+          {
+            printf '🛠️ **devops-review verdict:** %s\n\n' "$VERDICT"
+            printf '%s\n\n' "$SUMMARY"
+            printf '%s\n' "$FINDINGS"
+          } > /tmp/devops-review-body.txt
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
             -f event='COMMENT' \
-            -f body="$body" >/dev/null
+            -F body=@/tmp/devops-review-body.txt >/dev/null
 
       - name: Publish devops-review check-run
         if: always()
+        env:
+          IN_SCOPE_VERDICT: ${{ steps.review.outputs.verdict }}
+          IN_SCOPE_SUMMARY: ${{ steps.review.outputs.summary }}
+          IN_SCOPE_FINDINGS: ${{ steps.review.outputs.findings }}
+          SKIP_VERDICT: ${{ steps.skipped.outputs.verdict }}
+          SKIP_SUMMARY: ${{ steps.skipped.outputs.summary }}
+          SKIP_FINDINGS: ${{ steps.skipped.outputs.findings }}
+          SKIP_REASON: ${{ steps.ctx.outputs.skip_reason }}
         run: |
           set -euo pipefail
-          if [[ "${{ steps.ctx.outputs.skip_reason }}" == "" ]]; then
-            verdict="${{ steps.review.outputs.verdict }}"
-            summary="${{ steps.review.outputs.summary }}"
-            findings="${{ steps.review.outputs.findings }}"
+          if [ -z "$SKIP_REASON" ]; then
+            VERDICT="$IN_SCOPE_VERDICT"
+            SUMMARY="$IN_SCOPE_SUMMARY"
+            FINDINGS="$IN_SCOPE_FINDINGS"
           else
-            verdict="${{ steps.skipped.outputs.verdict }}"
-            summary="${{ steps.skipped.outputs.summary }}"
-            findings="${{ steps.skipped.outputs.findings }}"
+            VERDICT="$SKIP_VERDICT"
+            SUMMARY="$SKIP_SUMMARY"
+            FINDINGS="$SKIP_FINDINGS"
           fi
 
-          # APPROVE / COMMENT / SKIPPED → success; only REQUEST_CHANGES blocks
           conclusion='success'
-          if [[ "$verdict" == "REQUEST_CHANGES" ]]; then
+          if [ "$VERDICT" = "REQUEST_CHANGES" ]; then
             conclusion='failure'
           fi
           completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -193,8 +197,8 @@ print(s[i:j+1] if i!=-1 and j>=i else s)')"
             --arg head_sha "$HEAD_SHA" \
             --arg completed_at "$completed_at" \
             --arg conclusion "$conclusion" \
-            --arg title "devops-review: $verdict" \
-            --arg text "$findings" \
+            --arg title "devops-review: $VERDICT" \
+            --arg text "$FINDINGS" \
             '{name:"devops-review",head_sha:$head_sha,status:"completed",conclusion:$conclusion,completed_at:$completed_at,output:{title:$title,summary:$title,text:$text}}')
 
           if [ -n "$existing_id" ]; then

--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -140,12 +140,7 @@ jobs:
 
           raw="$(jq -r '.choices[0].message.content // ""' /tmp/tw-resp.json)"
           # Strip markdown code fences and isolate the outermost JSON object
-          parsed="$(RAW="$raw" python3 -c 'import os
-s=os.environ["RAW"].strip()
-if s.startswith("```"):
-    s="\n".join(l for l in s.splitlines() if not l.strip().startswith("```")).strip()
-i,j=s.find("{"),s.rfind("}")
-print(s[i:j+1] if i!=-1 and j>=i else s)')"
+          parsed="$(RAW="$raw" python3 -c 'import os; s=os.environ["RAW"].strip(); s="\n".join(l for l in s.splitlines() if not l.strip().startswith("```")).strip() if s.startswith("```") else s; i,j=s.find("{"),s.rfind("}"); print(s[i:j+1] if i!=-1 and j>=i else s)')"
           echo "$parsed" > /tmp/tw-verdict.json
           if ! jq -e . /tmp/tw-verdict.json >/dev/null 2>&1; then
             echo "::warning::LLM response was not valid JSON; defaulting to APPROVE"

--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -1,0 +1,300 @@
+name: tech-writer
+
+# Active doc maintenance: on every PR push, an LLM auditor reads the diff +
+# current docs, decides whether docs are sufficient, and if not, generates and
+# commits doc patches directly to the PR branch. Posts a `tech-writer-review`
+# check-run that gates merge (configured in branch protection).
+#
+# Loop prevention: skip if the last commit was made by this workflow itself
+# (committer email == tech-writer-bot@users.noreply.github.com).
+#
+# SECURITY: Runs on `pull_request` (NOT `pull_request_target`) so untrusted
+# fork code never executes with secrets. We only edit `docs/**` and root
+# markdown files; we never run any code from the PR.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write        # push doc patches to PR branch
+  pull-requests: write   # post review summary
+  checks: write          # publish tech-writer-review check-run
+  models: read           # GitHub Models inference
+
+concurrency:
+  group: tech-writer-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  tech-writer:
+    name: tech-writer-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      TW_BOT_EMAIL: tech-writer-bot@users.noreply.github.com
+      TW_BOT_NAME: tuning-coach tech-writer
+    steps:
+      - name: Verify AUTOMATION_PAT is configured
+        env:
+          PAT: ${{ secrets.AUTOMATION_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::AUTOMATION_PAT secret missing. GITHUB_TOKEN-pushed commits do not retrigger CI; required for tech-writer to push doc patches."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          # Use PAT so future pushes from this workflow re-trigger CI
+          token: ${{ secrets.AUTOMATION_PAT }}
+
+      - name: Loop guard — skip if last commit is from tech-writer
+        id: guard
+        run: |
+          set -euo pipefail
+          last_email=$(git log -1 --format=%ae HEAD)
+          echo "Last commit author email: $last_email"
+          if [ "$last_email" = "$TW_BOT_EMAIL" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Last commit was by tech-writer; skipping to prevent loop"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mark check-run in_progress
+        if: steps.guard.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
+            -f name='tech-writer-review' \
+            -f head_sha="${HEAD_SHA}" \
+            -f status='in_progress' \
+            -f "output[title]=Auditing docs" \
+            -f "output[summary]=Tech-writer agent is reviewing the diff and existing docs." >/dev/null
+
+      - name: Collect PR context
+        if: steps.guard.outputs.skip == 'false'
+        id: ctx
+        run: |
+          set -euo pipefail
+          # Files changed in this PR (excluding the docs the agent might touch
+          # — we still include them so the agent sees prior doc edits)
+          mapfile -t FILES < <(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          {
+            echo "changed_files<<EOF"
+            printf '%s\n' "${FILES[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          # Snapshot of all current docs (relative paths only — content fetched on demand by Python below)
+          {
+            echo "docs_inventory<<EOF"
+            find docs -type f \( -name '*.md' -o -name '*.yml' -o -name '*.html' \) | sort
+            ls -1 README.md CONTRIBUTING.md SECURITY.md CHANGELOG.md 2>/dev/null || true
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run tech-writer LLM pass
+        if: steps.guard.outputs.skip == 'false'
+        id: llm
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/tw
+
+          diff_content="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -H 'Accept: application/vnd.github.v3.diff')"
+          prompt_content="$(cat .github/agents/tech-writer.agent.md)"
+          changed_files="${{ steps.ctx.outputs.changed_files }}"
+          docs_inventory="${{ steps.ctx.outputs.docs_inventory }}"
+
+          # Read content of each existing docs file (cap individual files at
+          # 32KB to stay within token budget)
+          docs_corpus=""
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            size=$(stat -c%s "$f")
+            if [ "$size" -gt 32768 ]; then
+              docs_corpus="${docs_corpus}\n\n=== $f (truncated, original ${size} bytes) ===\n$(head -c 32768 "$f")"
+            else
+              docs_corpus="${docs_corpus}\n\n=== $f ===\n$(cat "$f")"
+            fi
+          done <<< "$docs_inventory"
+
+          jq -n \
+            --arg diff "$diff_content" \
+            --arg files "$changed_files" \
+            --arg inv "$docs_inventory" \
+            --arg corpus "$docs_corpus" \
+            --arg prompt "$prompt_content" \
+            '{
+              model: "gpt-4.1",
+              temperature: 0.1,
+              messages: [
+                {
+                  role: "system",
+                  content: "You are the tuning-coach tech-writer. Apply the conventions in the supplied tech-writer.agent.md verbatim. Your job: examine the PR diff and the current docs, decide whether the docs accurately and completely cover the changes. If yes, return verdict APPROVE with no patches. If no, return verdict UPDATES_NEEDED with a `patches` array specifying the FULL NEW CONTENT of each file to create or update. Use operation \"create\" for new files, \"update\" to replace existing files, \"delete\" to remove. Only touch docs/**, README.md, CONTRIBUTING.md, SECURITY.md, CHANGELOG.md. Never edit code. Be conservative: do not invent features; only document what the diff actually shows. Output strict JSON: {\"verdict\":\"APPROVE|UPDATES_NEEDED\",\"summary\":\"string\",\"patches\":[{\"path\":\"...\",\"operation\":\"create|update|delete\",\"content\":\"...\"}]}"
+                },
+                {
+                  role: "user",
+                  content: ("PR #" + $files + "\n\nChanged files:\n" + $files + "\n\nFull diff:\n" + $diff + "\n\nCurrent docs inventory:\n" + $inv + "\n\nCurrent docs content:\n" + $corpus + "\n\nTech-writer conventions (.github/agents/tech-writer.agent.md):\n" + $prompt)
+                }
+              ]
+            }' > /tmp/tw/req.json
+
+          curl -fsSL "https://models.inference.ai.azure.com/chat/completions" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data-binary @/tmp/tw/req.json > /tmp/tw/resp.json
+
+          raw="$(jq -r '.choices[0].message.content // ""' /tmp/tw/resp.json)"
+          # Strip markdown code fences if present
+          parsed="$(RAW="$raw" python3 -c 'import os,sys; s=os.environ["RAW"].strip();
+if s.startswith("```"):
+    s="\n".join(l for l in s.splitlines() if not l.strip().startswith("```")).strip()
+i,j=s.find("{"),s.rfind("}")
+print(s[i:j+1] if i!=-1 and j>=i else s)')"
+
+          echo "$parsed" > /tmp/tw/verdict.json
+          if ! jq -e . /tmp/tw/verdict.json >/dev/null 2>&1; then
+            echo "::warning::LLM response was not valid JSON; defaulting to APPROVE"
+            jq -n '{verdict:"APPROVE",summary:"Tech-writer LLM produced no parseable verdict; allowing merge.",patches:[]}' > /tmp/tw/verdict.json
+          fi
+
+          verdict=$(jq -r '.verdict' /tmp/tw/verdict.json)
+          summary=$(jq -r '.summary' /tmp/tw/verdict.json)
+          patch_count=$(jq -r '.patches | length' /tmp/tw/verdict.json)
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "patch_count=$patch_count" >> "$GITHUB_OUTPUT"
+          {
+            echo "summary<<EOF"
+            echo "$summary"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Verdict: $verdict | patches: $patch_count"
+
+      - name: Apply doc patches
+        if: steps.guard.outputs.skip == 'false' && steps.llm.outputs.patch_count != '0'
+        id: apply
+        run: |
+          set -euo pipefail
+          # Allowlist of paths the tech-writer is permitted to touch
+          allowed_re='^(docs/|README\.md$|CONTRIBUTING\.md$|SECURITY\.md$|CHANGELOG\.md$)'
+          touched=()
+          while read -r entry; do
+            path=$(jq -r '.path' <<<"$entry")
+            op=$(jq -r '.operation' <<<"$entry")
+            if ! [[ "$path" =~ $allowed_re ]]; then
+              echo "::warning::Refusing patch outside allowlist: $path"
+              continue
+            fi
+            case "$op" in
+              create|update)
+                mkdir -p "$(dirname "$path")"
+                jq -r '.content' <<<"$entry" > "$path"
+                touched+=("$path")
+                echo "  ${op}: $path"
+                ;;
+              delete)
+                if [ -f "$path" ]; then
+                  rm -f "$path"
+                  touched+=("$path")
+                  echo "  delete: $path"
+                fi
+                ;;
+              *)
+                echo "::warning::Unknown operation '$op' for $path"
+                ;;
+            esac
+          done < <(jq -c '.patches[]' /tmp/tw/verdict.json)
+
+          if [ "${#touched[@]}" -eq 0 ]; then
+            echo "no-files-changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "no-files-changed=false" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push doc patches
+        if: steps.guard.outputs.skip == 'false' && steps.llm.outputs.patch_count != '0' && steps.apply.outputs.no-files-changed != 'true'
+        run: |
+          set -euo pipefail
+          git config user.email "$TW_BOT_EMAIL"
+          git config user.name  "$TW_BOT_NAME"
+          # Only stage allowlisted paths (defensive)
+          git add -A docs/ README.md CONTRIBUTING.md SECURITY.md CHANGELOG.md 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No staged changes after allowlist filter; nothing to commit"
+            exit 0
+          fi
+          git commit -m "docs: tech-writer auto-update for PR #${PR_NUMBER}
+
+$(jq -r '.summary' /tmp/tw/verdict.json)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+          git push origin "HEAD:${HEAD_REF}"
+
+      - name: Post PR review summary
+        if: steps.guard.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          verdict="${{ steps.llm.outputs.verdict }}"
+          summary="${{ steps.llm.outputs.summary }}"
+          patch_count="${{ steps.llm.outputs.patch_count }}"
+
+          body="📝 **tech-writer verdict:** ${verdict}
+
+${summary}
+
+Patches applied: ${patch_count}"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+            -f event='COMMENT' \
+            -f body="$body" >/dev/null
+
+      - name: Finalize check-run
+        if: always() && steps.guard.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          verdict="${{ steps.llm.outputs.verdict || 'APPROVE' }}"
+          summary="${{ steps.llm.outputs.summary || 'Tech-writer skipped (no verdict produced).' }}"
+          # APPROVE = success (gates open); UPDATES_NEEDED + commit pushed = success too
+          # (next CI iteration will re-evaluate against the new HEAD). The required
+          # check is satisfied by the most recent run's success.
+          conclusion='success'
+
+          existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=tech-writer-review" --jq '.check_runs[0].id // empty')"
+          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          payload=$(jq -n \
+            --arg head_sha "$HEAD_SHA" \
+            --arg completed_at "$completed_at" \
+            --arg conclusion "$conclusion" \
+            --arg title "tech-writer: $verdict" \
+            --arg text "$summary" \
+            '{name:"tech-writer-review",head_sha:$head_sha,status:"completed",conclusion:$conclusion,completed_at:$completed_at,output:{title:$title,summary:$title,text:$text}}')
+
+          if [ -n "$existing_id" ]; then
+            update=$(jq 'del(.name,.head_sha)' <<<"$payload")
+            gh api "repos/${GITHUB_REPOSITORY}/check-runs/${existing_id}" -X PATCH --input - <<<"$update" >/dev/null
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST --input - <<<"$payload" >/dev/null
+          fi
+
+      - name: Skipped — finalize check-run as success
+        if: steps.guard.outputs.skip == 'true'
+        run: |
+          set -euo pipefail
+          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
+            -f name='tech-writer-review' \
+            -f head_sha="${HEAD_SHA}" \
+            -f status='completed' \
+            -f conclusion='success' \
+            -f completed_at="$completed_at" \
+            -f "output[title]=tech-writer: skipped (loop guard)" \
+            -f "output[summary]=Last commit on this PR was authored by tech-writer; skipping to prevent infinite loop." >/dev/null

--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -3,24 +3,32 @@ name: tech-writer
 # Active doc maintenance: on every PR push, an LLM auditor reads the diff +
 # current docs, decides whether docs are sufficient, and if not, generates and
 # commits doc patches directly to the PR branch. Posts a `tech-writer-review`
-# check-run that gates merge (configured in branch protection).
+# check-run that gates merge.
 #
-# Loop prevention: skip if the last commit was made by this workflow itself
-# (committer email == tech-writer-bot@users.noreply.github.com).
+# Convergence (instead of a forgeable loop guard):
+#   - When tech-writer pushes a doc-only commit, the resulting `synchronize`
+#     event runs the LLM again. It sees the just-applied docs and (with low
+#     temperature) returns APPROVE with no patches. No loop, no skip-trust.
 #
-# SECURITY: Runs on `pull_request` (NOT `pull_request_target`) so untrusted
-# fork code never executes with secrets. We only edit `docs/**` and root
-# markdown files; we never run any code from the PR.
+# SECURITY:
+#   - Triggers on `pull_request`, NOT `pull_request_target`, so untrusted fork
+#     code never executes with secrets.
+#   - All patches go through .github/scripts/apply-tech-writer-patches.py which
+#     refuses absolute paths, `..` segments, paths that resolve outside the
+#     repo root, and paths outside the docs/+root-md allowlist.
+#   - LLM-controlled strings are passed to bash via `env:`, never interpolated
+#     into `run:` bodies via `${{ }}`.
+#   - PR diff is truncated to 200KB before being sent to the LLM.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
-  contents: write        # push doc patches to PR branch
-  pull-requests: write   # post review summary
-  checks: write          # publish tech-writer-review check-run
-  models: read           # GitHub Models inference
+  contents: write
+  pull-requests: write
+  checks: write
+  models: read
 
 concurrency:
   group: tech-writer-${{ github.event.pull_request.number }}
@@ -37,16 +45,17 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
-      BASE_SHA: ${{ github.event.pull_request.base.sha }}
       TW_BOT_EMAIL: tech-writer-bot@users.noreply.github.com
       TW_BOT_NAME: tuning-coach tech-writer
+      MAX_DIFF_BYTES: '204800'   # 200 KB cap for jq + LLM input
+      MAX_DOC_BYTES: '32768'     # 32 KB per existing doc file
     steps:
       - name: Verify AUTOMATION_PAT is configured
         env:
           PAT: ${{ secrets.AUTOMATION_PAT }}
         run: |
           if [ -z "$PAT" ]; then
-            echo "::error::AUTOMATION_PAT secret missing. GITHUB_TOKEN-pushed commits do not retrigger CI; required for tech-writer to push doc patches."
+            echo "::error::AUTOMATION_PAT secret missing. GITHUB_TOKEN-pushed commits do not retrigger CI; required for tech-writer."
             exit 1
           fi
 
@@ -54,24 +63,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          # Use PAT so future pushes from this workflow re-trigger CI
           token: ${{ secrets.AUTOMATION_PAT }}
 
-      - name: Loop guard — skip if last commit is from tech-writer
-        id: guard
-        run: |
-          set -euo pipefail
-          last_email=$(git log -1 --format=%ae HEAD)
-          echo "Last commit author email: $last_email"
-          if [ "$last_email" = "$TW_BOT_EMAIL" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Last commit was by tech-writer; skipping to prevent loop"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Mark check-run in_progress
-        if: steps.guard.outputs.skip == 'false'
         run: |
           set -euo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
@@ -82,201 +76,175 @@ jobs:
             -f "output[summary]=Tech-writer agent is reviewing the diff and existing docs." >/dev/null
 
       - name: Collect PR context
-        if: steps.guard.outputs.skip == 'false'
         id: ctx
         run: |
           set -euo pipefail
-          # Files changed in this PR (excluding the docs the agent might touch
-          # — we still include them so the agent sees prior doc edits)
-          mapfile -t FILES < <(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
-          {
-            echo "changed_files<<EOF"
-            printf '%s\n' "${FILES[@]}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' > /tmp/tw-files.txt
 
-          # Snapshot of all current docs (relative paths only — content fetched on demand by Python below)
           {
-            echo "docs_inventory<<EOF"
             find docs -type f \( -name '*.md' -o -name '*.yml' -o -name '*.html' \) | sort
-            ls -1 README.md CONTRIBUTING.md SECURITY.md CHANGELOG.md 2>/dev/null || true
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            for f in README.md CONTRIBUTING.md SECURITY.md CHANGELOG.md; do
+              [ -f "$f" ] && echo "$f"
+            done
+          } > /tmp/tw-inventory.txt
 
-      - name: Run tech-writer LLM pass
-        if: steps.guard.outputs.skip == 'false'
-        id: llm
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/tw
-
-          diff_content="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -H 'Accept: application/vnd.github.v3.diff')"
-          prompt_content="$(cat .github/agents/tech-writer.agent.md)"
-          changed_files="${{ steps.ctx.outputs.changed_files }}"
-          docs_inventory="${{ steps.ctx.outputs.docs_inventory }}"
-
-          # Read content of each existing docs file (cap individual files at
-          # 32KB to stay within token budget)
-          docs_corpus=""
+          # Build a single capped doc corpus as a plain file (avoids shell quoting LLM-controlled bytes)
+          : > /tmp/tw-corpus.txt
           while IFS= read -r f; do
             [ -f "$f" ] || continue
-            size=$(stat -c%s "$f")
-            if [ "$size" -gt 32768 ]; then
-              docs_corpus="${docs_corpus}\n\n=== $f (truncated, original ${size} bytes) ===\n$(head -c 32768 "$f")"
-            else
-              docs_corpus="${docs_corpus}\n\n=== $f ===\n$(cat "$f")"
-            fi
-          done <<< "$docs_inventory"
+            echo -e "\n\n=== ${f} ===" >> /tmp/tw-corpus.txt
+            head -c "${MAX_DOC_BYTES}" "$f" >> /tmp/tw-corpus.txt
+          done < /tmp/tw-inventory.txt
 
+          # Truncate diff before passing to jq/LLM
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -H 'Accept: application/vnd.github.v3.diff' \
+            | head -c "${MAX_DIFF_BYTES}" > /tmp/tw-diff.txt
+
+          echo "files=$(wc -l < /tmp/tw-files.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Build LLM request
+        run: |
+          set -euo pipefail
+          # All inputs read from files via jq --rawfile so no shell interpolation
+          # of LLM-controllable bytes happens.
           jq -n \
-            --arg diff "$diff_content" \
-            --arg files "$changed_files" \
-            --arg inv "$docs_inventory" \
-            --arg corpus "$docs_corpus" \
-            --arg prompt "$prompt_content" \
+            --arg pr "${PR_NUMBER}" \
+            --rawfile diff /tmp/tw-diff.txt \
+            --rawfile files /tmp/tw-files.txt \
+            --rawfile inv /tmp/tw-inventory.txt \
+            --rawfile corpus /tmp/tw-corpus.txt \
+            --rawfile prompt .github/agents/tech-writer.agent.md \
             '{
               model: "gpt-4.1",
               temperature: 0.1,
               messages: [
                 {
                   role: "system",
-                  content: "You are the tuning-coach tech-writer. Apply the conventions in the supplied tech-writer.agent.md verbatim. Your job: examine the PR diff and the current docs, decide whether the docs accurately and completely cover the changes. If yes, return verdict APPROVE with no patches. If no, return verdict UPDATES_NEEDED with a `patches` array specifying the FULL NEW CONTENT of each file to create or update. Use operation \"create\" for new files, \"update\" to replace existing files, \"delete\" to remove. Only touch docs/**, README.md, CONTRIBUTING.md, SECURITY.md, CHANGELOG.md. Never edit code. Be conservative: do not invent features; only document what the diff actually shows. Output strict JSON: {\"verdict\":\"APPROVE|UPDATES_NEEDED\",\"summary\":\"string\",\"patches\":[{\"path\":\"...\",\"operation\":\"create|update|delete\",\"content\":\"...\"}]}"
+                  content: "You are the tuning-coach tech-writer. Apply the conventions in the supplied tech-writer.agent.md verbatim. Examine the PR diff and current docs and decide whether the docs accurately and completely cover the changes. If yes, return verdict APPROVE with no patches. If not, return verdict UPDATES_NEEDED with a `patches` array specifying the FULL NEW CONTENT of each file to create or update. Use operation \"create\" for new files, \"update\" to replace existing files, \"delete\" to remove. Only touch docs/**, README.md, CONTRIBUTING.md, SECURITY.md, CHANGELOG.md. Never edit code. Be conservative: do not invent features; only document what the diff actually shows. When this PR already contains adequate doc updates, return APPROVE — do not re-edit just to restyle. Output strict JSON: {\"verdict\":\"APPROVE|UPDATES_NEEDED\",\"summary\":\"string\",\"patches\":[{\"path\":\"...\",\"operation\":\"create|update|delete\",\"content\":\"...\"}]}"
                 },
                 {
                   role: "user",
-                  content: ("PR #" + $files + "\n\nChanged files:\n" + $files + "\n\nFull diff:\n" + $diff + "\n\nCurrent docs inventory:\n" + $inv + "\n\nCurrent docs content:\n" + $corpus + "\n\nTech-writer conventions (.github/agents/tech-writer.agent.md):\n" + $prompt)
+                  content: ("PR #" + $pr + "\n\nChanged files:\n" + $files + "\n\nDocs inventory:\n" + $inv + "\n\nFull diff (truncated):\n" + $diff + "\n\nCurrent docs (each capped):\n" + $corpus + "\n\nTech-writer conventions:\n" + $prompt)
                 }
               ]
-            }' > /tmp/tw/req.json
+            }' > /tmp/tw-req.json
 
+      - name: Call LLM
+        id: llm
+        run: |
+          set -euo pipefail
           curl -fsSL "https://models.inference.ai.azure.com/chat/completions" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data-binary @/tmp/tw/req.json > /tmp/tw/resp.json
+            --data-binary @/tmp/tw-req.json > /tmp/tw-resp.json
 
-          raw="$(jq -r '.choices[0].message.content // ""' /tmp/tw/resp.json)"
-          # Strip markdown code fences if present
-          parsed="$(RAW="$raw" python3 -c 'import os,sys; s=os.environ["RAW"].strip();
+          raw="$(jq -r '.choices[0].message.content // ""' /tmp/tw-resp.json)"
+          # Strip markdown code fences and isolate the outermost JSON object
+          parsed="$(RAW="$raw" python3 -c 'import os
+s=os.environ["RAW"].strip()
 if s.startswith("```"):
     s="\n".join(l for l in s.splitlines() if not l.strip().startswith("```")).strip()
 i,j=s.find("{"),s.rfind("}")
 print(s[i:j+1] if i!=-1 and j>=i else s)')"
-
-          echo "$parsed" > /tmp/tw/verdict.json
-          if ! jq -e . /tmp/tw/verdict.json >/dev/null 2>&1; then
+          echo "$parsed" > /tmp/tw-verdict.json
+          if ! jq -e . /tmp/tw-verdict.json >/dev/null 2>&1; then
             echo "::warning::LLM response was not valid JSON; defaulting to APPROVE"
-            jq -n '{verdict:"APPROVE",summary:"Tech-writer LLM produced no parseable verdict; allowing merge.",patches:[]}' > /tmp/tw/verdict.json
+            jq -n '{verdict:"APPROVE",summary:"Tech-writer LLM produced no parseable verdict; allowing merge.",patches:[]}' > /tmp/tw-verdict.json
           fi
 
-          verdict=$(jq -r '.verdict' /tmp/tw/verdict.json)
-          summary=$(jq -r '.summary' /tmp/tw/verdict.json)
-          patch_count=$(jq -r '.patches | length' /tmp/tw/verdict.json)
+          verdict=$(jq -r '.verdict' /tmp/tw-verdict.json)
+          patch_count=$(jq -r '.patches | length' /tmp/tw-verdict.json)
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
           echo "patch_count=$patch_count" >> "$GITHUB_OUTPUT"
-          {
-            echo "summary<<EOF"
-            echo "$summary"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "Verdict: $verdict | patches: $patch_count"
+          echo "Verdict=$verdict patches=$patch_count"
 
-      - name: Apply doc patches
-        if: steps.guard.outputs.skip == 'false' && steps.llm.outputs.patch_count != '0'
+      - name: Apply doc patches (validated paths)
+        if: steps.llm.outputs.patch_count != '0'
         id: apply
         run: |
           set -euo pipefail
-          # Allowlist of paths the tech-writer is permitted to touch
-          allowed_re='^(docs/|README\.md$|CONTRIBUTING\.md$|SECURITY\.md$|CHANGELOG\.md$)'
-          touched=()
-          while read -r entry; do
-            path=$(jq -r '.path' <<<"$entry")
-            op=$(jq -r '.operation' <<<"$entry")
-            if ! [[ "$path" =~ $allowed_re ]]; then
-              echo "::warning::Refusing patch outside allowlist: $path"
-              continue
-            fi
-            case "$op" in
-              create|update)
-                mkdir -p "$(dirname "$path")"
-                jq -r '.content' <<<"$entry" > "$path"
-                touched+=("$path")
-                echo "  ${op}: $path"
-                ;;
-              delete)
-                if [ -f "$path" ]; then
-                  rm -f "$path"
-                  touched+=("$path")
-                  echo "  delete: $path"
-                fi
-                ;;
-              *)
-                echo "::warning::Unknown operation '$op' for $path"
-                ;;
-            esac
-          done < <(jq -c '.patches[]' /tmp/tw/verdict.json)
-
-          if [ "${#touched[@]}" -eq 0 ]; then
+          python3 .github/scripts/apply-tech-writer-patches.py /tmp/tw-verdict.json | tee /tmp/tw-apply.log
+          if grep -q '^applied=0$' /tmp/tw-apply.log; then
             echo "no-files-changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          else
+            echo "no-files-changed=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "no-files-changed=false" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push doc patches
-        if: steps.guard.outputs.skip == 'false' && steps.llm.outputs.patch_count != '0' && steps.apply.outputs.no-files-changed != 'true'
+        if: steps.llm.outputs.patch_count != '0' && steps.apply.outputs.no-files-changed != 'true'
+        env:
+          # Pass LLM summary via env to avoid template injection into bash
+          PATCH_SUMMARY: ${{ steps.llm.outputs.verdict }}
         run: |
           set -euo pipefail
           git config user.email "$TW_BOT_EMAIL"
           git config user.name  "$TW_BOT_NAME"
-          # Only stage allowlisted paths (defensive)
-          git add -A docs/ README.md CONTRIBUTING.md SECURITY.md CHANGELOG.md 2>/dev/null || true
+          # Defensive: only stage allowlisted paths
+          git add -A docs/ 2>/dev/null || true
+          for f in README.md CONTRIBUTING.md SECURITY.md CHANGELOG.md; do
+            [ -e "$f" ] && git add "$f" || true
+          done
           if git diff --cached --quiet; then
             echo "No staged changes after allowlist filter; nothing to commit"
             exit 0
           fi
-          git commit -m "docs: tech-writer auto-update for PR #${PR_NUMBER}
-
-$(jq -r '.summary' /tmp/tw/verdict.json)
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+          # Read summary from verdict file directly (never let LLM bytes hit shell)
+          SUMMARY=$(jq -r '.summary' /tmp/tw-verdict.json)
+          export SUMMARY
+          # Use git -F so commit message body comes from a file, not the shell
+          {
+            echo "docs: tech-writer auto-update for PR #${PR_NUMBER}"
+            echo
+            printf '%s\n' "$SUMMARY"
+            echo
+            echo "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+          } > /tmp/tw-commit-msg.txt
+          git commit -F /tmp/tw-commit-msg.txt
           git push origin "HEAD:${HEAD_REF}"
 
       - name: Post PR review summary
-        if: steps.guard.outputs.skip == 'false'
+        env:
+          VERDICT: ${{ steps.llm.outputs.verdict }}
+          PATCH_COUNT: ${{ steps.llm.outputs.patch_count }}
         run: |
           set -euo pipefail
-          verdict="${{ steps.llm.outputs.verdict }}"
-          summary="${{ steps.llm.outputs.summary }}"
-          patch_count="${{ steps.llm.outputs.patch_count }}"
-
-          body="📝 **tech-writer verdict:** ${verdict}
-
-${summary}
-
-Patches applied: ${patch_count}"
+          # Read summary from verdict file (LLM-controlled bytes never hit a `${{ }}` expansion)
+          SUMMARY=$(jq -r '.summary' /tmp/tw-verdict.json)
+          {
+            printf '📝 **tech-writer verdict:** %s\n\n' "$VERDICT"
+            printf '%s\n\n' "$SUMMARY"
+            printf 'Patches applied: %s\n' "$PATCH_COUNT"
+          } > /tmp/tw-review-body.txt
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
             -f event='COMMENT' \
-            -f body="$body" >/dev/null
+            -F body=@/tmp/tw-review-body.txt >/dev/null
 
       - name: Finalize check-run
-        if: always() && steps.guard.outputs.skip == 'false'
+        if: always()
+        env:
+          VERDICT: ${{ steps.llm.outputs.verdict || 'APPROVE' }}
         run: |
           set -euo pipefail
-          verdict="${{ steps.llm.outputs.verdict || 'APPROVE' }}"
-          summary="${{ steps.llm.outputs.summary || 'Tech-writer skipped (no verdict produced).' }}"
-          # APPROVE = success (gates open); UPDATES_NEEDED + commit pushed = success too
-          # (next CI iteration will re-evaluate against the new HEAD). The required
-          # check is satisfied by the most recent run's success.
+          # Required check is satisfied by every run posting `success`. The LLM
+          # already had its chance — APPROVE means accept; UPDATES_NEEDED means
+          # we just pushed docs and the next CI iteration will re-evaluate.
           conclusion='success'
+          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          if [ -f /tmp/tw-verdict.json ]; then
+            SUMMARY=$(jq -r '.summary' /tmp/tw-verdict.json)
+          else
+            SUMMARY='Tech-writer did not produce a verdict (likely an error before LLM).'
+          fi
 
           existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=tech-writer-review" --jq '.check_runs[0].id // empty')"
-          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          payload=$(jq -n \
+          payload=$(SUMMARY="$SUMMARY" jq -n \
             --arg head_sha "$HEAD_SHA" \
             --arg completed_at "$completed_at" \
             --arg conclusion "$conclusion" \
-            --arg title "tech-writer: $verdict" \
-            --arg text "$summary" \
-            '{name:"tech-writer-review",head_sha:$head_sha,status:"completed",conclusion:$conclusion,completed_at:$completed_at,output:{title:$title,summary:$title,text:$text}}')
+            --arg verdict "$VERDICT" \
+            --arg text "$SUMMARY" \
+            '{name:"tech-writer-review",head_sha:$head_sha,status:"completed",conclusion:$conclusion,completed_at:$completed_at,output:{title:("tech-writer: " + $verdict),summary:("tech-writer: " + $verdict),text:$text}}')
 
           if [ -n "$existing_id" ]; then
             update=$(jq 'del(.name,.head_sha)' <<<"$payload")
@@ -284,17 +252,3 @@ Patches applied: ${patch_count}"
           else
             gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST --input - <<<"$payload" >/dev/null
           fi
-
-      - name: Skipped — finalize check-run as success
-        if: steps.guard.outputs.skip == 'true'
-        run: |
-          set -euo pipefail
-          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
-            -f name='tech-writer-review' \
-            -f head_sha="${HEAD_SHA}" \
-            -f status='completed' \
-            -f conclusion='success' \
-            -f completed_at="$completed_at" \
-            -f "output[title]=tech-writer: skipped (loop guard)" \
-            -f "output[summary]=Last commit on this PR was authored by tech-writer; skipping to prevent infinite loop." >/dev/null

--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -48,8 +48,6 @@ jobs:
       TW_BOT_EMAIL: tech-writer-bot@users.noreply.github.com
       TW_BOT_NAME: tuning-coach tech-writer
       MAX_DIFF_BYTES: '60000'    # ~60 KB cap for jq + LLM input
-      MAX_DOC_BYTES: '6000'      # ~6 KB per existing doc file
-      MAX_CORPUS_BYTES: '80000'  # hard cap for combined doc corpus
     steps:
       - name: Verify AUTOMATION_PAT is configured
         env:
@@ -92,16 +90,6 @@ jobs:
           # Build a single capped doc corpus as a plain file (avoids shell quoting LLM-controlled bytes).
           # Hard-cap the total corpus; once we exceed MAX_CORPUS_BYTES, stop appending.
           : > /tmp/tw-corpus.txt
-          while IFS= read -r f; do
-            [ -f "$f" ] || continue
-            current_size=$(stat -c%s /tmp/tw-corpus.txt 2>/dev/null || echo 0)
-            if [ "$current_size" -ge "${MAX_CORPUS_BYTES}" ]; then
-              echo -e "\n\n=== (corpus truncated; remaining files omitted) ===" >> /tmp/tw-corpus.txt
-              break
-            fi
-            echo -e "\n\n=== ${f} ===" >> /tmp/tw-corpus.txt
-            head -c "${MAX_DOC_BYTES}" "$f" >> /tmp/tw-corpus.txt
-          done < /tmp/tw-inventory.txt
 
           # Truncate diff before passing to jq/LLM
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -H 'Accept: application/vnd.github.v3.diff' \

--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -203,7 +203,7 @@ jobs:
           PATCH_COUNT: ${{ steps.llm.outputs.patch_count }}
         run: |
           set -euo pipefail
-          # Read summary from verdict file (LLM-controlled bytes never hit a `${{ }}` expansion)
+          # Read summary from verdict file (LLM-controlled bytes never hit a GHA expression context)
           SUMMARY=$(jq -r '.summary' /tmp/tw-verdict.json)
           {
             printf '📝 **tech-writer verdict:** %s\n\n' "$VERDICT"

--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -47,8 +47,9 @@ jobs:
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
       TW_BOT_EMAIL: tech-writer-bot@users.noreply.github.com
       TW_BOT_NAME: tuning-coach tech-writer
-      MAX_DIFF_BYTES: '204800'   # 200 KB cap for jq + LLM input
-      MAX_DOC_BYTES: '32768'     # 32 KB per existing doc file
+      MAX_DIFF_BYTES: '60000'    # ~60 KB cap for jq + LLM input
+      MAX_DOC_BYTES: '6000'      # ~6 KB per existing doc file
+      MAX_CORPUS_BYTES: '80000'  # hard cap for combined doc corpus
     steps:
       - name: Verify AUTOMATION_PAT is configured
         env:
@@ -88,10 +89,16 @@ jobs:
             done
           } > /tmp/tw-inventory.txt
 
-          # Build a single capped doc corpus as a plain file (avoids shell quoting LLM-controlled bytes)
+          # Build a single capped doc corpus as a plain file (avoids shell quoting LLM-controlled bytes).
+          # Hard-cap the total corpus; once we exceed MAX_CORPUS_BYTES, stop appending.
           : > /tmp/tw-corpus.txt
           while IFS= read -r f; do
             [ -f "$f" ] || continue
+            current_size=$(stat -c%s /tmp/tw-corpus.txt 2>/dev/null || echo 0)
+            if [ "$current_size" -ge "${MAX_CORPUS_BYTES}" ]; then
+              echo -e "\n\n=== (corpus truncated; remaining files omitted) ===" >> /tmp/tw-corpus.txt
+              break
+            fi
             echo -e "\n\n=== ${f} ===" >> /tmp/tw-corpus.txt
             head -c "${MAX_DOC_BYTES}" "$f" >> /tmp/tw-corpus.txt
           done < /tmp/tw-inventory.txt

--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -1,0 +1,57 @@
+name: Update open PR branches after main push
+
+# Repo's branch protection requires linear history but allow_update_branch may
+# not always trigger fast enough. This fires on every push to main and updates
+# each open non-draft PR branch so the auto-merge gate sees a fresh green build
+# before merging the next PR. Mirrors the workflow used in copilot-matrix-bot.
+#
+# Uses AUTOMATION_PAT (not GITHUB_TOKEN) so the resulting branch update
+# re-triggers PR Checks (GITHUB_TOKEN-triggered updates are suppressed).
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: update-pr-branches
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify AUTOMATION_PAT is configured
+        env:
+          PAT: ${{ secrets.AUTOMATION_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::AUTOMATION_PAT secret missing. GITHUB_TOKEN-triggered branch updates do not re-trigger CI."
+            exit 1
+          fi
+
+      - name: Update each open PR's branch
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PRS=$(gh pr list --repo "$REPO" --state open --base main \
+            --json number,isDraft,mergeStateStatus \
+            --jq '.[] | select(.isDraft == false and (.mergeStateStatus == "BEHIND" or .mergeStateStatus == "DIRTY" or .mergeStateStatus == "UNKNOWN")) | .number')
+          if [ -z "$PRS" ]; then
+            echo "No open non-draft PRs needing update."
+            exit 0
+          fi
+          for PR in $PRS; do
+            echo "::group::PR #$PR"
+            if gh pr update-branch "$PR" --repo "$REPO" 2>&1; then
+              echo "Updated PR #$PR"
+            else
+              echo "::warning::PR #$PR could not be updated (likely conflicts); skipping"
+            fi
+            echo "::endgroup::"
+          done

--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Verify AUTOMATION_PAT is configured
         env:


### PR DESCRIPTION
Removes manual babysitting from agent-driven PR flow.

## Problems fixed

1. **Copilot PRs sat in draft forever** — `copilot-swe-agent[bot]` opens PRs as draft and never marks them ready. Required by `agent-review.yml` skip + `auto-merge.yml` `!draft` gate. Manual `gh pr ready N` was needed every time.
2. **CI didn't fire on draft → ready** — `ci.yml` only triggered on default `pull_request` types. When a draft was marked ready, sidecar/overlay/CodeQL checks never ran, so required checks stayed missing forever.
3. **Stale PRs blocked merge** — `allow_update_branch=false` and no auto-update workflow. PR #51 went BEHIND main and required manual `gh pr update-branch`.
4. **`automerge` label never auto-applied** — `auto-merge.yml` requires the label but nothing applied it.

## Changes

- **`ci.yml`**: trigger on `ready_for_review` + `review_requested` so checks fire as soon as Copilot signals done (or on any draft → ready transition).
- **`copilot-finalize.yml`** (new): on `review_requested` from sender=`Copilot`, mark PR ready + apply `automerge` label. Uses `AUTOMATION_PAT` so downstream events fire (GITHUB_TOKEN-triggered events are suppressed by GH anti-recursion).
- **`update-pr-branches.yml`** (new): on every push to main, update each open non-draft PR's branch. Same pattern as copilot-matrix-bot.

## Out of band (already applied)

- `allow_update_branch=true` set on repo
- `AUTOMATION_PAT` secret added to repo
- `automerge` label applied to in-flight PR #48

## Security notes

`copilot-finalize.yml` and `update-pr-branches.yml` run on `pull_request_target`/`push` with write privileges. Both are API-only (no `actions/checkout`, no PR-code execution). Inline comments warn future editors.

## Verification

Once merged: next Copilot PR should mark itself ready, get the automerge label, run all required checks, and squash-merge unattended once green.