### PR TITLE
ci: stop skipping dependabot in required-check workflows

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   conventional:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -39,7 +39,6 @@ jobs:
     name: tech-writer-review
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Branch protection treats 'skipped via if:' as 'never reported' for
required checks, so dependabot PRs get permanently BLOCKED on
tech-writer-review and conventional. Real-world impact: PRs #91, #92
and any future dep bump.

Fix: drop the dependabot if-guards. action-semantic-pull-request
accepts dependabot's 'chore(scope)(deps): Bump X' titles, and the
tech-writer LLM returns APPROVE on no-doc-impact diffs (low-temp
convergence pattern already in place).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
