### PR TITLE
docs(agents): vendor copilot workflow hardening + cloud-agent playbooks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,6 +99,7 @@ See `docs/adr/` for architecture decisions.
 | `.github/agents/MANIFEST.md` | Vendored team agent versions |
 | `.github/agents/telemetry-expert.agent.md` | Forza UDP packet schema, sim physics |
 | `.github/agents/race-engineer.agent.md` | Real-world tuning knowledge |
+| `.github/instructions/MANIFEST.md` | Vendored copilot instructions (security, workflow hardening, cloud-agent playbooks) |
 | `docs/adr/` | Architecture Decision Records |
 | `sidecar/Cargo.toml` | Rust workspace + crate |
 | `overlay/index.html` | SimHub overlay entry |
@@ -125,3 +126,6 @@ the producer's open issues for the phase 1 backlog).
 - Team workflow: `.github/agents/coordinator.agent.md`
 - Domain knowledge: `.github/agents/telemetry-expert.agent.md`,
   `.github/agents/race-engineer.agent.md`
+- Workflow / agent gotchas: `.github/instructions/llm-workflow-hardening.instructions.md`,
+  `.github/instructions/cloud-agent-ci-gate.instructions.md`,
+  `.github/instructions/cloud-agent-dirty-pr.instructions.md`

--- a/.github/instructions/MANIFEST.md
+++ b/.github/instructions/MANIFEST.md
@@ -1,14 +1,22 @@
 # Vendored Copilot Instructions
 
-These `*.instructions.md` files are vendored copies from
-[github/awesome-copilot](https://github.com/github/awesome-copilot).
+These `*.instructions.md` files are read by GitHub Copilot whenever the file
+being edited matches the `applyTo:` frontmatter glob. Two sources:
 
-GitHub Copilot reads any `.github/instructions/*.instructions.md` file whose
-`applyTo:` frontmatter glob matches the current file path. Updates land here
-manually; re-vendor from upstream when the originals change.
+1. **`awesome-copilot/`** — vendored copies from
+   [github/awesome-copilot](https://github.com/github/awesome-copilot).
+   Re-vendor manually when originals change.
+2. **`homelab-copilot/`** — vendored from `mac-reichelt/homelab-copilot`
+   notes (`notes/copilot/*.md`). These capture lessons from this repo's own
+   agent automation pipeline and the cloud `copilot-swe-agent` workflow.
 
 | File | Source | applyTo |
 |---|---|---|
 | `security-and-owasp.instructions.md` | awesome-copilot/instructions/ | `**` |
 | `ai-prompt-engineering-safety-best-practices.instructions.md` | awesome-copilot/instructions/ | `*` |
 | `containerization-docker-best-practices.instructions.md` | awesome-copilot/instructions/ | `**/Dockerfile,**/compose*.yml,...` |
+| `llm-workflow-hardening.instructions.md` | homelab-copilot/notes/copilot/llm-workflow-hardening.md | `.github/workflows/**` |
+| `llm-workflow-payload-limits.instructions.md` | homelab-copilot/notes/copilot/llm-workflow-payload-limits.md | `.github/workflows/**` |
+| `cloud-agent-ci-gate.instructions.md` | homelab-copilot/notes/copilot/cloud-agent-ci-gate.md | `**` |
+| `cloud-agent-dirty-pr.instructions.md` | homelab-copilot/notes/copilot/cloud-agent-dirty-pr.md | `**` |
+

--- a/.github/instructions/cloud-agent-ci-gate.instructions.md
+++ b/.github/instructions/cloud-agent-ci-gate.instructions.md
@@ -1,0 +1,129 @@
+---
+applyTo: '**'
+description: 'Playbook for unblocking cloud Copilot agent PRs whose workflows are stuck in action_required state. Apply when a copilot-swe-agent or release-please PR has empty statusCheckRollup or BLOCKED merge state with no failing checks.'
+---
+
+# Cloud Agent CI Gate (PR Checks `action_required`)
+
+When the cloud `copilot-swe-agent` pushes to a PR branch in this repo, the
+workflows can land in status `action_required` instead of running. Auto-merge
+gate stalls until a human (or this script) approves.
+
+Root cause: GitHub treats first-party-pushes-from-bot-actor like fork PRs and
+requires explicit approval before workflows run. The repo setting
+`fork-pr-contributor-approval = first_time_contributors_new_to_github`
+(see `llm-workflow-hardening.instructions.md` Pattern 9) eliminates this for
+**known** bot accounts, but new bot accounts and release-please runs can still
+trigger it.
+
+## Detect
+
+```bash
+BR=copilot/feat-whatever
+gh run list -b "$BR" --json status,conclusion,databaseId \
+  --jq '[.[] | select(.status=="completed" and .conclusion=="action_required")][0].databaseId'
+```
+
+## Approve + rerun
+
+```bash
+RUN_ID=$(gh run list -b "$BR" --json status,conclusion,databaseId \
+  --jq '[.[] | select(.status=="completed" and .conclusion=="action_required")][0].databaseId')
+gh run rerun "$RUN_ID"
+```
+
+`gh run rerun` on an `action_required` run implicitly approves it. After this,
+PR Checks runs normally.
+
+## Drain script (for active PR sweeps)
+
+```bash
+for pr in $(gh pr list --state open --json number,headRefName --jq '.[].number'); do
+  br=$(gh pr view "$pr" --json headRefName --jq .headRefName)
+  rid=$(gh run list -b "$br" --json status,conclusion,databaseId \
+    --jq '[.[] | select(.status=="completed" and .conclusion=="action_required")][0].databaseId')
+  [ -n "$rid" ] && { echo "PR #$pr → rerunning $rid"; gh run rerun "$rid"; }
+done
+```
+
+## When `gh run rerun` is not enough
+
+Some PRs (especially first-time-contributor + release-please) start with NO
+workflows triggered at all — `statusCheckRollup: []`. Symptoms:
+
+- `gh pr view N --json statusCheckRollup` → `checks: []`
+- `gh run list --branch <copilot-branch>` → empty or all `action_required`
+- `gh api .../actions/runs/$id/approve` → 403 "not from a fork pull request"
+
+**Fix:** close + reopen the PR as a maintainer.
+
+```bash
+gh pr close N && sleep 2 && gh pr reopen N
+# CI fires within seconds, runs normally, no manual approve needed
+```
+
+This is the canonical workaround for release-please's "chore: release main"
+PRs as well — those are opened by `github-actions[bot]` which suppresses
+workflow triggers by design (anti-recursion).
+
+## Other gotchas
+
+### `gh run approve` does not exist
+
+Use the API (and only on actual fork PRs):
+
+```bash
+gh api -X POST repos/$REPO/actions/runs/$RUN_ID/approve   # only fork PRs
+gh api -X POST repos/$REPO/actions/runs/$RUN_ID/rerun     # works for action_required from cloud-swe-agent
+```
+
+The cloud-agent's `action_required` runs are NOT fork PRs (they're same-repo
+branches), so `/approve` returns HTTP 403 "This run is not from a fork pull
+request". Use `/rerun` instead.
+
+### Squash-merge sometimes drops `Closes #N`
+
+When the agent's PR body uses bullet-list form (`- Closes #N`) instead of a
+leading sentence, the linked issue may not auto-close. Manually
+`gh issue close N` after merge if needed.
+
+### `gh pr merge --auto` quirk
+
+Returns silently on success but `gh pr view N --json autoMergeRequest` may
+show null briefly. If state stays NULL after CI green, re-run the command.
+
+### Bot assignment via REST is flaky
+
+`gh issue edit N --add-assignee Copilot` intermittently 404s. Prefer GraphQL:
+
+```bash
+gh api graphql -f query='mutation($i:ID!,$a:[ID!]!){replaceActorsForAssignable(input:{assignableId:$i,actorIds:$a}){clientMutationId}}' \
+  -f i="$ISSUE_NODE_ID" -f a='["BOT_kgDOC9w8XQ","MDQ6VXNlcjg0NDA3NDEz"]'
+```
+(Copilot bot + maintainer as co-assignees.)
+
+### `GITHUB_TOKEN` push doesn't trigger downstream workflows
+
+Any event created by `GITHUB_TOKEN` does not trigger another workflow
+(anti-recursion). For downstream triggering use `secrets.AUTOMATION_PAT`. See
+`llm-workflow-hardening.instructions.md` Pattern 7.
+
+### `gh pr update-branch` from a maintainer bypasses `action_required`
+
+When a sibling PR merges and your branch goes BEHIND, run
+`gh pr update-branch <N> --rebase` — the resulting push is from the
+maintainer's identity, so CI runs immediately without needing close+reopen.
+This is what `update-pr-branches.yml` automates.
+
+### Job-name collisions across workflow files create silent merge blocks
+
+GitHub treats same-named jobs across different workflows as the SAME check
+context for branch protection purposes. Always give workflow jobs unique
+`name:` values, especially when adding new workflows to a repo with existing
+required checks.
+
+### GitHub Models API needs `models: read` permission
+
+Workflows that call `https://models.inference.ai.azure.com/...` (or the new
+`gh models` API) get `curl: (22) error: 401` without it. Add to the workflow's
+`permissions:` block.

--- a/.github/instructions/cloud-agent-dirty-pr.instructions.md
+++ b/.github/instructions/cloud-agent-dirty-pr.instructions.md
@@ -1,0 +1,140 @@
+---
+applyTo: '**'
+description: 'Manual rescue playbook for cloud Copilot agent PRs that go DIRTY (merge conflicts) when sibling PRs merge first. Apply when gh pr view N --json mergeStateStatus returns DIRTY and the agent has failed to self-rebase.'
+---
+
+# Cloud Copilot agent — DIRTY PR rescue playbook
+
+When the Copilot coding agent (cloud, `copilot-swe-agent`) has multiple PRs
+in flight and one lands, siblings go `mergeable_state: DIRTY` with conflicts.
+The agent **can** rebase itself if pinged, but often rebases against **stale
+main** and stays DIRTY. Faster to do it yourself via worktrees + docker.
+
+## Symptoms
+
+- `gh pr view N --json mergeStateStatus` → `DIRTY`
+- Commenting "please rebase" → agent pushes a merge commit against stale main
+- Still DIRTY after its attempt
+
+## Manual rescue (per PR)
+
+```bash
+# 1. Worktree per branch (one worktree dir per branch keeps WIP isolated)
+BR=copilot/feat-whatever
+git -C ~/repos/tuning-coach worktree add ~/repos/.worktrees/tuning-coach/$BR $BR
+cd ~/repos/.worktrees/tuning-coach/$BR
+
+# 2. Reset and merge fresh main (prefer merge over rebase when the branch
+#    already has its OWN merge commits — rebase will re-apply commits already
+#    upstreamed and confuse patch application)
+git fetch origin --quiet
+git reset --hard origin/$BR --quiet
+git merge origin/main --no-edit
+
+# 3. Resolve conflicts. Typical pattern in this Rust repo:
+#    - Cargo.toml: keep BOTH dep additions
+#    - Cargo.lock: checkout --ours then regenerate (see below)
+#    - src/main.rs: keep both 'mod X;' declarations
+
+# 4. Regenerate Cargo.lock + verify
+git checkout --ours sidecar/Cargo.lock
+docker run --rm --network host -u $(id -u):$(id -g) \
+  -v "$PWD:/work" -w /work/sidecar \
+  -e CARGO_HOME=/work/.cargo-home \
+  rust:1.88-slim bash -c "cargo generate-lockfile && cargo check --all-targets"
+
+# 5. Stage, commit
+git add -A
+GIT_EDITOR=true git commit --no-edit    # accept auto-generated merge msg
+
+# 6. Push (use force-with-lease if rebased; plain push if merged)
+git push origin HEAD:$BR
+
+# 7. Rerun action_required workflows (Copilot bot push gate)
+for id in $(gh run list --branch $BR --limit 20 \
+  --json databaseId,conclusion \
+  -q '.[] | select(.conclusion=="action_required") | .databaseId'); do
+  gh run rerun $id
+done
+
+# 8. Re-arm auto-merge (push clears it)
+gh pr merge $N --auto --squash
+```
+
+## Why rebase fails and merge succeeds
+
+When the branch tip contains its own merge-from-main commit (`Merge branch
+'main' into ...`), a linear `git rebase origin/main` tries to replay commits
+that are already upstreamed → apply fails → "dropping ... patch contents
+already upstream" → **but the unique branch changes get lost too**.
+
+Merge preserves the branch's state and only needs you to resolve the delta
+against today's main. Force-push not needed.
+
+## Resolving blocking review threads
+
+`required_conversation_resolution: true` + Copilot's self-review threads =
+BLOCKED even with all-green checks. Outdated threads don't auto-resolve.
+
+```bash
+# Find unresolved
+gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){
+  pullRequest(number:N){reviewThreads(first:50){
+    nodes{id isResolved isOutdated path}}}}}' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | .id'
+
+# Resolve each
+for id in $(...); do
+  gh api graphql -f query="mutation{resolveReviewThread(input:{threadId:\"$id\"}){thread{isResolved}}}"
+done
+```
+
+## rustfmt ping-pong
+
+Workflow runs `cargo fmt --all --check`. When you change a call (e.g. drop a
+type conversion), the line length changes and rustfmt's wrap decision flips.
+Each commit can trigger the opposite decision. Faster: run rustfmt locally
+first via `cargo fmt --all` in a docker container that has rustfmt
+(`rust:1.88-slim` does **NOT** — `rustfmt` component is missing). Use
+`rust:1.88` (full image, ~1.5GB) or apply `rustup component add rustfmt`
+in the script. Otherwise: read the diff hunks from CI and apply line-by-line
+— but be ready for 2–3 round trips as wrap decisions cascade.
+
+## dependency-review-action scans `.cargo-home/`
+
+If you set `CARGO_HOME=/work/.cargo-home` in your docker rust build and don't
+gitignore `.cargo-home/`, every `git add -A` sweeps in 10000+ cached registry
+files. The `actions/dependency-review-action` then scans those cached crates'
+internal `Cargo.lock` files (NOT just the repo's lockfile!) and flags moderate
+vulns in deps that aren't even in the build graph. **Always add `.cargo-home/`
+to `.gitignore` before first commit.**
+
+## Additive merge regex (use with care)
+
+For purely additive conflicts (e.g. two PRs each add fields to the same
+struct), this Python one-liner resolves all conflict markers by concatenating
+both sides:
+
+```python
+import re, sys
+p = sys.argv[1]
+s = open(p).read()
+s = re.sub(
+    r'<<<<<<< HEAD\n(.*?)=======\n(.*?)>>>>>>> [^\n]+\n',
+    lambda m: m.group(1) + m.group(2),
+    s, flags=re.DOTALL)
+open(p, 'w').write(s)
+```
+
+**Mandatory post-checks** (the regex silently produces buggy code otherwise):
+
+```bash
+python3 -c "import ast; ast.parse(open('path/to/file.py').read())"  # syntax check
+grep -nE '^\s*(def|async def) [a-z_]+' path/to/file.py | sort -k2 | uniq -d  # dup methods
+grep -nE '^\s+[a-z_]+: [A-Z]' path/to/config.py | awk '{print $1}' | sort | uniq -d  # dup fields
+```
+
+Python silently accepts duplicate `def` and duplicate dataclass fields — the
+**last** definition wins, shadowing earlier ones. Anti-pattern: `with`
+statements. Python's `with (a, b)` tuple form vs `with a, \\ b`
+line-continuation form is NOT mergeable by this regex — needs hand-resolution.

--- a/.github/instructions/llm-workflow-hardening.instructions.md
+++ b/.github/instructions/llm-workflow-hardening.instructions.md
@@ -1,0 +1,224 @@
+---
+applyTo: '.github/workflows/**'
+description: 'Security and reliability patterns for LLM-driven GitHub Actions workflows. Apply when writing or editing any workflow that consumes model output, posts PR/issue comments, or runs against agent-authored content.'
+---
+
+# Hardening LLM-driven GitHub Actions workflows
+
+Lessons from this repo's agent automation pipeline (`agent-review.yml`,
+`tech-writer.yml`, `devops-review.yml`, etc.). Read this before adding or
+editing any workflow that runs an LLM, posts an LLM verdict, or applies
+model-emitted patches.
+
+## Threat model
+
+Any workflow that takes an LLM response and uses it in shell, file paths, or
+PR/issue API calls must assume the LLM output is **attacker-controlled bytes**
+(prompt injection from PR diffs, comments, or external content). Patterns
+that look benign explode when the LLM emits backticks, `$()`, `..`, etc.
+
+## Pattern 1: shell template injection via outputs
+
+**BAD:**
+```yaml
+- name: Publish review
+  run: |
+    summary="${{ steps.review.outputs.summary }}"
+    body=$(cat <<'EOF'
+    🤖 verdict: __SUMMARY__
+    EOF
+    )
+    body="${body/__SUMMARY__/${summary}}"
+    gh api ... -f body="$body"
+```
+LLM emits `` `StorageError::Schema` `` → bash command-substitutes it →
+`/tmp/...sh: line 22: StorageError::Schema: command not found`. Step fails,
+required check blocks PR. Real incident on PR #84.
+
+**GOOD:**
+```yaml
+- name: Publish review
+  env:
+    REVIEW_SUMMARY: ${{ steps.review.outputs.summary }}
+  run: |
+    {
+      echo "verdict: $verdict"
+      echo
+      echo "$REVIEW_SUMMARY"
+    } > /tmp/body.md
+    jq -n --rawfile body /tmp/body.md '{event:"COMMENT", body:$body}' \
+      | gh api .../pulls/$PR/reviews --input -
+```
+- Move LLM-controlled values to `env:` block (no `${{ }}` in script body).
+- Reference as `"$VAR"` (quoted) — bash does NOT command-substitute inside
+  double quotes from env vars, only inside `${{ }}` interpolated literals.
+- Build body via `printf` / `echo` to a file, send via `jq --rawfile` so JSON
+  encoding handles all special bytes.
+
+Canonical example: `agent-review.yml` lines 163–227.
+
+## Pattern 2: path traversal in patch appliers
+
+**BAD:** Allowlist via regex prefix
+```bash
+[[ "$path" =~ ^(docs/|README\.md$|...) ]]   # allows docs/../.git/config
+mkdir -p "$(dirname "$path")"
+echo "$content" > "$path"
+git add "$path"
+```
+LLM emits `docs/../.git/hooks/pre-commit` → file written → next `git commit`
+executes it with PAT exposed via `.git/config` extraheader.
+
+**GOOD:** Realpath validation in Python
+```python
+ALLOWED = ["docs", "README.md", ...]
+real_root = Path.cwd().resolve()
+target = (real_root / path).resolve()
+target.relative_to(real_root)            # raises if outside
+assert ".." not in Path(path).parts
+assert not Path(path).is_absolute()
+assert any(target.relative_to(real_root).parts[0] == a or
+           str(target.relative_to(real_root)) == a for a in ALLOWED)
+```
+Canonical example: `.github/scripts/apply-tech-writer-patches.py`.
+
+## Pattern 3: don't use forgeable loop guards
+
+Bot-author email check (`if last commit author == bot-email skip`) is bypassed
+by `git commit --author='X <bot@email>'`. Better:
+- **Convergence**: Let the LLM see its own output via the next `synchronize`
+  event. With low temperature it returns APPROVE on the second pass. No skip.
+- Or post `neutral` check status on skip so PR still merges.
+
+## Pattern 4: dependabot-skip on required checks = permanent block
+
+**BAD:** `if: github.event.pull_request.user.login != 'dependabot[bot]'`
+on a workflow whose check name is in branch-protection required list.
+
+GitHub branch protection treats "skipped because `if:`" as "never reported"
+→ check is forever pending → `BLOCKED` mergeStateStatus.
+
+**GOOD:** Either
+- Don't skip dependabot, let the workflow run (LLM will likely APPROVE).
+- Or split into two jobs sharing the check name: real job for non-dependabot,
+  skip-success job for dependabot that just publishes the check as `success`.
+- Or simpler: omit the workflow from the required list (`gh api repos/$O/$R/branches/main/protection/required_status_checks/contexts -X DELETE -f 'contexts[]=NAME'`).
+
+Real incident: `pr-title.yml` and `tech-writer.yml` both had the skip,
+permanently blocking dependabot PRs #91, #92. Fix landed in PR #93.
+
+## Pattern 5: GHA expression parsing inside shell comments
+
+Workflow validation FAILS on a literal `${{ }}` substring even inside a `run:`
+block's `# comment`. Symptom: `unexpected end of input while parsing variable
+access`. Workaround: rephrase comments; never include literal `${{ }}` syntax
+outside of intended expressions.
+
+Co-symptom: when a workflow fails YAML/expression validation, `gh api`
+sometimes shows the run with `name: .github/workflows/X.yml` (path instead of
+declared `name:`) AND lists jobs from sibling workflows under it. Misleading
+— check `actionlint` or the raw workflow log.
+
+## Pattern 6: CodeQL actions-queries crash on emoji+printf
+
+`codeql/actions-queries v0.6.25` crashes with `String ... is not valid
+Unicode` when parsing `printf '🤖 ... %s\n' "$x"` (emoji + format spec).
+Tooling bug, not a real finding. Workaround: replace `printf` with sequential
+`echo` lines, or strip the emoji.
+
+## Pattern 7: AUTOMATION_PAT for downstream triggering
+
+Commits pushed by `${{ secrets.GITHUB_TOKEN }}` and events triggered by it
+(label add, ready_for_review, etc.) are SUPPRESSED by GitHub anti-recursion
+rules — downstream workflows do not fire.
+
+Solution: use a fine-grained PAT in `secrets.AUTOMATION_PAT`. Scopes:
+contents R/W, PRs R/W, issues R/W, actions R/W, metadata R. Cannot manage
+user-owned Projects v2 (PAT limitation).
+
+## Pattern 8: `pull_request` vs `pull_request_target`
+
+- `pull_request`: PR's head code, NO secrets. Safe for `actions/checkout`.
+- `pull_request_target`: base-repo context WITH secrets. Only safe for
+  metadata-only API workflows. NEVER `actions/checkout` in this mode.
+
+`copilot-finalize.yml` uses `pull_request_target` (needs to mark draft PRs
+ready) but does no checkout. `tech-writer.yml` uses `pull_request` (checks
+out PR head, runs LLM analysis on it). `auto-approve-bots.yml` uses
+`pull_request_target` (needs `pull-requests: write`) but does no checkout.
+
+## Pattern 9: fork-PR contributor approval gate
+
+Symptom: Copilot/bot PRs sit forever with workflows stuck in `action_required`.
+You cannot `gh api .../actions/runs/$R/approve` non-fork runs (returns 403
+"not from a fork pull request"). Closing+reopening the PR retriggers them.
+
+Real fix is the repo-level setting:
+
+```bash
+gh api repos/$O/$R/actions/permissions/fork-pr-contributor-approval \
+  -X PUT -f approval_policy=first_time_contributors_new_to_github
+```
+
+Values:
+- `first_time_contributors` — default; gates all bots that haven't merged yet
+- `first_time_contributors_new_to_github` — only gates brand-new GH accounts;
+  Copilot/Dependabot/etc. bot accounts are fine. **Recommended for agent repos.**
+- `all_external_contributors` — paranoid mode
+
+## Pattern 10: bot-only PR auto-approval
+
+Goal: bots merge unimpeded, humans get reviewed.
+
+1. Branch protection: `required_approving_review_count = 1`,
+   `dismiss_stale_reviews = true`.
+2. Add `.github/workflows/auto-approve-bots.yml` on `pull_request_target`
+   triggers (`opened, reopened, synchronize, ready_for_review`). Job-level
+   `if:` allowlists author logins; shell step re-validates author with
+   `case`/`esac` defense-in-depth and validates `PR_NUMBER` is integer.
+3. Use `secrets.GITHUB_TOKEN` (not AUTOMATION_PAT) — `github-actions[bot]`
+   approving counts as a review by a different account than the PR author.
+4. Workflow CANNOT auto-approve its own introducing PR (chicken-and-egg);
+   admin-merge that one bootstrap PR.
+
+Allowlist examples (case patterns escape brackets):
+```bash
+case "$PR_AUTHOR" in
+  dependabot\[bot\]|copilot-swe-agent\[bot\]|github-actions\[bot\]) ;;
+  *) echo "not allowlisted" >&2; exit 1 ;;
+esac
+```
+
+`devops-review` LLM may flag env-var interpolation as injection — false
+positive when vars are in `"$VAR"` (env vars are not re-evaluated by shell
+inside double quotes). Add the shell-side allowlist anyway to satisfy it.
+
+## Pattern 11: GitHub Models payload limits
+
+See companion instruction `llm-workflow-payload-limits.instructions.md`.
+TL;DR: do not include the file corpus in the LLM payload — diff + filename
+inventory + agent prompt only.
+
+## Reference workflow files in this repo
+
+| File | Purpose |
+|------|---------|
+| `agent-review.yml` | LLM code reviewer — env-var pattern, jq --rawfile body |
+| `tech-writer.yml` | LLM doc auditor with patch commits — path validator |
+| `devops-review.yml` | LLM workflow auditor (audit-only) |
+| `copilot-finalize.yml` | Auto-mark Copilot PRs ready + label automerge |
+| `auto-assign-copilot.yml` | Assign Copilot+owner on `ready-for-coding-agent` label |
+| `update-pr-branches.yml` | Keep open PRs current with main on push |
+| `auto-approve-bots.yml` | Auto-approve PRs from trusted bot allowlist |
+
+All except `auto-approve-bots.yml` require `secrets.AUTOMATION_PAT` for
+downstream triggering.
+
+## Real incidents (chronological)
+
+- 2026-04-26: `tech-writer` HTTP 413 → dropped doc corpus from payload
+- 2026-04-26: `agent-review.yml` shell injection via `` `StorageError::Schema` `` → env-var hardening (PR #89)
+- 2026-04-26: CodeQL crash on `printf '🤖 ... %s\n'` → swapped to plain echo
+- 2026-04-26: dependabot-skip on `tech-writer-review` + `conventional` required checks → dependabot PRs permanently BLOCKED → dropped `if:` skips (PR #93)
+- 2026-04-26: Copilot PRs stuck on `action_required` → flipped fork-pr-contributor-approval to `first_time_contributors_new_to_github`
+- 2026-04-26: bot-only PR policy → `auto-approve-bots.yml` + `required_approving_review_count=1` (PR #94)

--- a/.github/instructions/llm-workflow-payload-limits.instructions.md
+++ b/.github/instructions/llm-workflow-payload-limits.instructions.md
@@ -1,0 +1,35 @@
+---
+applyTo: '.github/workflows/**'
+description: 'GitHub Models API payload-size guidance for workflows. Apply when adding or editing a workflow that posts to models.inference.ai.azure.com or the gh models API.'
+---
+
+# GitHub Models API payload limits in workflows
+
+## Symptom
+
+`curl: (22) The requested URL returned error: 413` from
+`https://models.inference.ai.azure.com/chat/completions` even with payloads
+that look small in raw bytes (~125KB).
+
+## Root cause
+
+Models endpoint rejects payloads well below stated token limits when the
+*encoded* JSON is large. Newline-heavy `--rawfile` content explodes via JSON
+escaping (`\n`), doubling effective size. Saw rejection at:
+- 60KB diff + 80KB doc corpus + 6KB agent prompt
+- Worked at 60KB diff + 0KB corpus + 6KB agent prompt
+
+## Pattern that works (mirrors `agent-review.yml`)
+
+Send only:
+1. PR diff (cap with `head -c`)
+2. Changed-files list
+3. Agent prompt file
+
+Do NOT include the full repo file corpus. If LLM needs to update an existing
+file, it emits FULL NEW content blind (acceptable trade-off for v1).
+
+## Reference
+
+- `.github/workflows/tech-writer.yml`
+- `.github/workflows/agent-review.yml` (canonical pattern)


### PR DESCRIPTION
Vendors four instructions from mac-reichelt/homelab-copilot notes into
.github/instructions/ so the cloud copilot-swe-agent and local Copilot CLI
sessions inherit the same lessons learned in this repo's automation:

- llm-workflow-hardening.instructions.md (applyTo: .github/workflows/**)
  11 patterns for safely consuming LLM output in workflows: shell template
  injection, path traversal, dependabot-skip blocking required checks,
  CodeQL emoji crash, AUTOMATION_PAT, pull_request vs pull_request_target,
  fork-pr-contributor-approval policy, bot-only auto-approve.

- llm-workflow-payload-limits.instructions.md (applyTo: .github/workflows/**)
  GitHub Models 413 root cause + safe payload pattern.

- cloud-agent-ci-gate.instructions.md (applyTo: **)
  Playbook for action_required workflow runs, gh run rerun, close+reopen
  fallback, GraphQL bot assignment, GITHUB_TOKEN anti-recursion notes.

- cloud-agent-dirty-pr.instructions.md (applyTo: **)
  Manual rescue via worktrees + docker rust build + cargo lockfile regen
  for DIRTY PRs after sibling merges, plus rustfmt ping-pong + .cargo-home
  gitignore footgun.

Updates MANIFEST.md and copilot-instructions.md Key Files / Related
sections to point at the new vendored files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
