### PR TITLE
chore: add VS Code dev configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.{js,html,css,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.toml]
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 100
 
-[*.{js,html,css,json}]
+[*.{js,html,css,json,yml,yaml}]
 indent_size = 2
 
 [*.md]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    // tasks.json "type": "cargo" + settings.json rust-analyzer.*
+    "rust-lang.rust-analyzer",
+    // settings.json "[toml]" defaultFormatter
+    "tamasfe.even-better-toml",
+    // settings.json "[javascript]" / "[html]" / "[css]" defaultFormatter
+    "esbenp.prettier-vscode",
+    // launch.json "type": "lldb"
+    "vadimcn.vscode-lldb"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    // ── Sidecar — debug ───────────────────────────────────────────────────────
+    {
+      "name": "sidecar: debug",
+      "type": "lldb",
+      "request": "launch",
+      "cargo": {
+        "args": [
+          "build",
+          "--manifest-path",
+          "sidecar/Cargo.toml"
+        ],
+        "filter": {
+          "name": "tuning-coach-sidecar",
+          "kind": "bin"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}/sidecar",
+      "env": {
+        "RUST_LOG": "debug",
+        "RUST_BACKTRACE": "1"
+      },
+      "sourceLanguages": [
+        "rust"
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,35 @@
+{
+  // ── Rust (sidecar) ────────────────────────────────────────────────────────
+  "rust-analyzer.linkedProjects": ["sidecar/Cargo.toml"],
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.extraArgs": ["--all-targets", "--", "-D", "warnings"],
+  "rust-analyzer.cargo.features": "all",
+  "rust-analyzer.procMacro.enable": true,
+  "rust-analyzer.inlayHints.parameterHints.enable": true,
+  "rust-analyzer.inlayHints.typeHints.enable": true,
+  // ── JavaScript / overlay ──────────────────────────────────────────────────
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  // ── TOML ─────────────────────────────────────────────────────────────────
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml"
+  },
+  // ── Editor ────────────────────────────────────────────────────────────────
+  "editor.formatOnSave": true,
+  "editor.rulers": [100],
+  // ── File exclusions ───────────────────────────────────────────────────────
+  "files.exclude": {
+    "sidecar/target": true
+  },
+  "search.exclude": {
+    "sidecar/target": true,
+    "**/*.lock": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,103 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    // ── Sidecar (Rust) ───────────────────────────────────────────────────────
+    {
+      "label": "sidecar: build (debug)",
+      "type": "cargo",
+      "command": "build",
+      "args": ["--manifest-path", "sidecar/Cargo.toml"],
+      "group": { "kind": "build", "isDefault": true },
+      "presentation": { "panel": "shared", "reveal": "always" },
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "sidecar: build (release)",
+      "type": "cargo",
+      "command": "build",
+      "args": ["--manifest-path", "sidecar/Cargo.toml", "--release"],
+      "group": "build",
+      "presentation": { "panel": "shared", "reveal": "always" },
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "sidecar: run",
+      "type": "cargo",
+      "command": "run",
+      "args": ["--manifest-path", "sidecar/Cargo.toml"],
+      "group": "none",
+      "isBackground": true,
+      "presentation": { "panel": "dedicated", "reveal": "always" },
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "sidecar: test",
+      "type": "cargo",
+      "command": "test",
+      "args": ["--manifest-path", "sidecar/Cargo.toml", "--all-targets"],
+      "group": { "kind": "test", "isDefault": true },
+      "presentation": { "panel": "shared", "reveal": "always" },
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "sidecar: test (single, enter name)",
+      "type": "cargo",
+      "command": "test",
+      "args": ["--manifest-path", "sidecar/Cargo.toml", "--all-targets", "${input:testFilter}"],
+      "group": "test",
+      "presentation": { "panel": "shared", "reveal": "always" },
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "sidecar: clippy",
+      "type": "cargo",
+      "command": "clippy",
+      "args": ["--manifest-path", "sidecar/Cargo.toml", "--all-targets", "--", "-D", "warnings"],
+      "group": "none",
+      "presentation": { "panel": "shared", "reveal": "always" },
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "sidecar: fmt check",
+      "type": "shell",
+      "command": "cargo fmt --manifest-path sidecar/Cargo.toml --all --check",
+      "group": "none",
+      "presentation": { "panel": "shared", "reveal": "always" },
+      "problemMatcher": []
+    },
+    {
+      "label": "sidecar: fmt (apply)",
+      "type": "shell",
+      "command": "cargo fmt --manifest-path sidecar/Cargo.toml --all",
+      "group": "none",
+      "presentation": { "panel": "shared", "reveal": "silent" },
+      "problemMatcher": []
+    },
+    {
+      "label": "sidecar: print config (defaults)",
+      "type": "cargo",
+      "command": "run",
+      "args": ["--manifest-path", "sidecar/Cargo.toml", "--", "--print-config"],
+      "group": "none",
+      "presentation": { "panel": "shared", "reveal": "always" },
+      "problemMatcher": ["$rustc"]
+    },
+    // ── CI-style gate (matches what CI runs) ─────────────────────────────────
+    {
+      "label": "ci: lint + test",
+      "dependsOrder": "sequence",
+      "dependsOn": ["sidecar: fmt check", "sidecar: clippy", "sidecar: test"],
+      "group": "none",
+      "presentation": { "panel": "shared", "reveal": "always" },
+      "problemMatcher": []
+    }
+  ],
+  "inputs": [
+    {
+      "id": "testFilter",
+      "type": "promptString",
+      "description": "Test name filter (substring match)",
+      "default": ""
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -86,7 +86,7 @@
     {
       "label": "ci: lint + test",
       "dependsOrder": "sequence",
-      "dependsOn": ["sidecar: fmt check", "sidecar: clippy", "sidecar: test"],
+      "dependsOn": ["sidecar: fmt check", "sidecar: clippy", "sidecar: test", "sidecar: build (release)"],
       "group": "none",
       "presentation": { "panel": "shared", "reveal": "always" },
       "problemMatcher": []


### PR DESCRIPTION
## Summary

Adds VS Code workspace configuration so contributors can build, test, and debug the sidecar without any manual setup beyond installing the recommended extensions.

## Changes

### `.editorconfig` (new)
- Canonical indent, line-ending, trailing-whitespace, and final-newline rules for all file types
- Moves these settings out of `.vscode/` so any editor respects them

### `.vscode/settings.json` (new)
- `rust-analyzer` pointed at `sidecar/Cargo.toml`, clippy on-save with `-D warnings`
- Prettier as default formatter for JS/HTML/CSS; `even-better-toml` for TOML
- `sidecar/target` excluded from explorer and search

### `.vscode/tasks.json` (new)
- **Default build** (`Ctrl+Shift+B`): `sidecar: build (debug)`
- **Default test** (`Ctrl+Shift+P` → Run Test Task): `sidecar: test --all-targets`
- Additional tasks: build release, run, clippy, fmt check/apply, print config, `ci: lint + test` chain

### `.vscode/launch.json` (new)
- Single LLDB debug config for the sidecar binary (`F5`)
- Sets `RUST_LOG=debug` and `RUST_BACKTRACE=1`

### `.vscode/extensions.json` (new)
- Four recommendations, each tied to a specific reference in the other config files: `rust-analyzer`, `even-better-toml`, `prettier`, `vscode-lldb`
