### PR TITLE
ci: let tech-writer pass for Dependabot and fork PRs without AUTOMATION_PAT

### DIFF
--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -51,22 +51,35 @@ jobs:
       TW_BOT_NAME: tuning-coach tech-writer
       MAX_DIFF_BYTES: '25000'    # ~25 KB cap to stay under GitHub Models 8K-token input budget
     steps:
-      - name: Verify AUTOMATION_PAT is configured
+      - name: Detect tech-writer capability
+        id: cap
         env:
           PAT: ${{ secrets.AUTOMATION_PAT }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [ -z "$PAT" ]; then
-            echo "::error::AUTOMATION_PAT secret missing. GITHUB_TOKEN-pushed commits do not retrigger CI; required for tech-writer."
+          set -euo pipefail
+          if [ -n "${PAT:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "tech-writer enabled (AUTOMATION_PAT present)."
+          elif [ "$HEAD_REPO" != "$BASE_REPO" ] || [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::AUTOMATION_PAT unavailable in this context (fork or Dependabot PR). Skipping tech-writer doc audit and passing the required check."
+          else
+            echo "::error::AUTOMATION_PAT secret is missing on a trusted PR. Configure the AUTOMATION_PAT repo secret so tech-writer can push doc updates."
             exit 1
           fi
 
       - uses: actions/checkout@v6
+        if: steps.cap.outputs.enabled == 'true'
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.AUTOMATION_PAT }}
 
       - name: Mark check-run in_progress
+        if: steps.cap.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
@@ -77,6 +90,7 @@ jobs:
             -f "output[summary]=Tech-writer agent is reviewing the diff and existing docs." >/dev/null
 
       - name: Collect PR context
+        if: steps.cap.outputs.enabled == 'true'
         id: ctx
         run: |
           set -euo pipefail
@@ -100,6 +114,7 @@ jobs:
           echo "files=$(wc -l < /tmp/tw-files.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Build LLM request
+        if: steps.cap.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           # All inputs read from files via jq --rawfile so no shell interpolation
@@ -127,6 +142,7 @@ jobs:
             }' > /tmp/tw-req.json
 
       - name: Call LLM
+        if: steps.cap.outputs.enabled == 'true'
         id: llm
         run: |
           set -euo pipefail
@@ -170,7 +186,7 @@ jobs:
           echo "Verdict=$verdict patches=$patch_count"
 
       - name: Apply doc patches (validated paths)
-        if: steps.llm.outputs.patch_count != '0'
+        if: steps.cap.outputs.enabled == 'true' && steps.llm.outputs.patch_count != '0'
         id: apply
         run: |
           set -euo pipefail
@@ -182,7 +198,7 @@ jobs:
           fi
 
       - name: Commit and push doc patches
-        if: steps.llm.outputs.patch_count != '0' && steps.apply.outputs.no-files-changed != 'true'
+        if: steps.cap.outputs.enabled == 'true' && steps.llm.outputs.patch_count != '0' && steps.apply.outputs.no-files-changed != 'true'
         env:
           # Pass LLM summary via env to avoid template injection into bash
           PATCH_SUMMARY: ${{ steps.llm.outputs.verdict }}
@@ -214,6 +230,7 @@ jobs:
           git push origin "HEAD:${HEAD_REF}"
 
       - name: Post PR review summary
+        if: steps.cap.outputs.enabled == 'true'
         env:
           VERDICT: ${{ steps.llm.outputs.verdict }}
           PATCH_COUNT: ${{ steps.llm.outputs.patch_count }}
@@ -231,7 +248,7 @@ jobs:
             -F body=@/tmp/tw-review-body.txt >/dev/null
 
       - name: Finalize check-run
-        if: always()
+        if: always() && steps.cap.outputs.enabled == 'true'
         env:
           VERDICT: ${{ steps.llm.outputs.verdict || 'APPROVE' }}
         run: |


### PR DESCRIPTION
## Problem

The `tech-writer-review` required check hard-failed (`exit 1`) in its first step whenever `secrets.AUTOMATION_PAT` was empty. Dependabot-triggered runs and fork PRs never receive Actions secrets, so this required check could **never** pass for them — those PRs could only be merged with an admin override.

The PAT is only needed by the later steps that push LLM-generated doc commits, call the GitHub Models API, and post check-runs — none of which are possible in the Dependabot/fork context anyway.

## Fix

Replace the hard-failing "Verify AUTOMATION_PAT is configured" step with a capability-detection step (`id: cap`) that:

- **PAT present** → `enabled=true` (unchanged behavior for trusted PRs).
- **Fork or Dependabot PR, no PAT** → `enabled=false`, emits a `::notice::`, and the job proceeds to skip the doc audit.
- **Trusted PR but PAT genuinely missing** → still hard-fails with an actionable `::error::`.

Every subsequent step is gated on `steps.cap.outputs.enabled == 'true'` (combined with existing conditions where present). When disabled, only the capability step runs and succeeds, so the job's overall conclusion is `success` and the required `tech-writer-review` job-level check passes — exactly how Build/Test pass for Dependabot today.

No `if:` was added to the job itself, and no other files, env vars, the system prompt, or `TW_BOT_NAME` were changed.

## Validation

Manual review confirms all 8 downstream steps are gated, the capability step is unconditional, and the job-level config is untouched. (No YAML linter was available in the environment; changes were reviewed line-by-line.)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>